### PR TITLE
Allow the Server to bind to a random free port.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -127,7 +127,7 @@ Server.prototype.listen = function() {
 	var args = [2775];
 	if (typeof arguments[0] == 'function') {
 		args[1] = arguments[0];
-	} else if (arguments[0]) {
+	} else if (arguments.length > 0) {
 		args = arguments;
 	}
 	return net.Server.prototype.listen.apply(this, args);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "mocha -u tdd"
   },
   "devDependencies": {
-    "mocha": "~1.9.0"
+    "mocha": "~1.9.0",
+    "q": "^1.0.1"
   },
   "dependencies": {
     "iconv": "~2.0.4"

--- a/test/smpp.js
+++ b/test/smpp.js
@@ -1,0 +1,37 @@
+var assert = require('assert'),
+    Q = require('q'),
+    Server = require('../lib/smpp').Server;
+
+suite('Server', function() {
+	var server;
+
+	setup(function() {
+		server = new Server();
+	});
+
+	suite('listen()', function() {
+		teardown(function (done) {
+			server.close(done);
+		});
+
+		test('should bind to a random port', function(done) {
+			var port;
+
+			Q.ninvoke(server, 'listen', 0)
+			.then(function () {
+				port = server.address().port;
+				assert.ok(port > 0, 'invalid first port');
+				return Q.ninvoke(server, 'close');
+			})
+			.then(function () {
+				return Q.ninvoke(server, 'listen', 0);
+			})
+			.then(function () {
+				var newPort = server.address().port;
+				assert.ok(newPort > 0, 'invalid second port');
+				assert.notEqual(newPort, port, 'same port');
+			})
+			.nodeify(done);
+		});
+	});
+});


### PR DESCRIPTION
This change allows `0` to be passed as the port number which causes Node to pick a random available port. This is useful for scenarios where a fixed port isn't guaranteed to be available (like automated build systems).
