### PR TITLE
Fix encode PDU

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -370,11 +370,21 @@ filters.message = {
 		}
 		var message = typeof value == 'string' ? value : value.message;
 		if (typeof message == 'string') {
-			var encoding = encodings.detect(message);
-			if (message && this.data_coding === null) {
+			if (message) {
+				var encoding = encodings.default;
+				if (this.data_coding === null) {
+					encoding = encodings.detect(message);
+				} else {
+					for (var key in consts.ENCODING) {
+						if (consts.ENCODING[key] === this.data_coding) {
+							encoding = key;
+							break;
+						}
+					}
+				}
 				this.data_coding = consts.ENCODING[encoding];
+				message = encodings[encoding].encode(message);
 			}
-			message = encodings[encoding].encode(message);
 		}
 		if (!value.udh || !value.udh.length) {
 			return message;


### PR DESCRIPTION
When sending a PDU is not possible to specify the desired encoding. The data_coding parameter is ignored.
