### PR TITLE
Update pdu.js

### DIFF
--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -84,7 +84,8 @@ PDU.prototype.fromBuffer = function(buffer) {
 	pduHeadParams.forEach(function(key, i) {
 		this[key] = buffer.readUInt32BE(i * 4);
 	}.bind(this));
-	var params, offset = 16;
+	//Since each pduHeaderParam is 4 bytes/octets, the offset is equal to the total length of the pduHeadParams*4, its better to use that basis for maintainance.
+	var params, offset = this.pduHeadParams.length * 4;
 	if (this.command_length > PDU.maxLength) {
 		throw Error('PDU length was too large (' + this.command_length +
 			', maximum is ' + PDU.maxLength + ').');
@@ -153,7 +154,8 @@ PDU.prototype._initBuffer = function() {
 };
 
 PDU.prototype.toBuffer = function() {
-	this.command_length = 16;
+	//Since each pduHeaderParam is 4 bytes/octets, the offset is equal to the total length of the pduHeadParams*4, its better to use that basis for maintainance.
+	this.command_length = this.pduHeadParams.length * 4;
 	if (this.command_status) {
 		return this._initBuffer();
 	}
@@ -170,7 +172,8 @@ PDU.prototype.toBuffer = function() {
 		}
 	}
 	var buffer = this._initBuffer();
-	var offset = 16;
+	//Since each pduHeaderParam is 4 bytes/octets, the offset is equal to the total length of the pduHeadParams*4, its better to use that basis for maintainance.
+	var offset = this.pduHeaderParams.length * 4;
 	for (var key in params) {
 		params[key].type.write(this[key], buffer, offset);
 		offset += params[key].type.size(this[key]);


### PR DESCRIPTION
Since each pduHeaderParam is 4 bytes/octets, the "offset" is equal to the total length of the pduHeadParams.length * 4. Using the basis is maintenance friendly. I noticed this while trying to leverage your code base to build a module for CUAP USSD protocol for USSDC that only support TCP/IP CUAP protocol.