### PR TITLE
enquire_link timer option to keep server alive

### DIFF
--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -15,6 +15,7 @@ function Session(options) {
 	this.paused = false;
 	this._busy = false;
 	this._callbacks = [];
+	this._interval = 0;
 	if (options.socket) {
 		this.socket = options.socket;
 	} else {
@@ -24,6 +25,11 @@ function Session(options) {
 		this.socket = transport.connect(this.options);
 		this.socket.on('connect', function() {
 			self.emit('connect');
+			if(self.options.auto_enquire_link_period) {
+				self._interval = setInterval(function() {
+					self.enquire_link();
+				}, self.options.auto_enquire_link_period);
+			}
 		});
 		this.socket.on('secureConnect', function() {
 			self.emit('secureConnect');
@@ -32,9 +38,17 @@ function Session(options) {
 	this.socket.on('readable', this._extractPDUs.bind(this));
 	this.socket.on('close', function() {
 		self.emit('close');
+		if(self._interval) {
+			clearInterval(self._interval);
+			self._interval = 0;
+		}
 	});
 	this.socket.on('error', function(e) {
 		self.emit('error', e);
+		if(self._interval) {
+			clearInterval(self._interval);
+			self._interval = 0;
+		}
 	});
 }
 


### PR DESCRIPTION
Hello,

Some servers require enquire_link heartbeat as mentioned in #49. 

This PR allows it to be done in library level instead of application level. It is entirely optional. One can set auto_enquire_link_period to whatever the limit is.

**It's client only.**

``` javascript
var session = smpp.connect({url:'ssmpp://server.example.com', auto_enquire_link_period:15000});
```

I think this could be improved by someone else. Like the server support terminating sessions which unable to send enquire_link to the server on the time and a better variable naming scheme 😄 
