### PR TITLE
Added SMSC Default Alphabet encoding constant

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -1209,6 +1209,7 @@ var consts = {
 		WAP:         0x12
 	},
 	ENCODING: {
+		SMSC_DEFAULT:       0x00,
 		ASCII:              0x01,
 		IA5:                0x01,
 		LATIN1:             0x03,

--- a/test/filters.js
+++ b/test/filters.js
@@ -20,8 +20,11 @@ describe('time', function() {
 			assert.deepEqual(filters.time.decode.call(pdu, encoded), value);
 		});
 		it('should convert an SMPP relative time to JavaScript Date object', function() {
-			var expected = new Date(Date.now() + 2 * 3600000 + 6 * 60000 + 30 * 1000);
-			assert.deepEqual(filters.time.decode.call(pdu, encoded2), expected);
+			var expected = new Date(Date.now() + 2 * 3600000 + 6 * 60000 + 30 * 1000).setMilliseconds(0);
+			expected = new Date(expected);
+			var actual = filters.time.decode.call(pdu, encoded2).setMilliseconds(0);
+			actual = new Date(actual);
+			assert.deepEqual(actual, expected);
 		});
 	});
 });


### PR DESCRIPTION
According to SMPP v3.4 it's possible to set `data_coding=0x00` (SMSC Default Alphabet). Some SMSC even requires to explicitly set it to default one, otherwise Mobile station (MS) receives corrupted SMS.

Also updated time filtering test - if test lags a bit, `Date` objects do not match due to difference of milliseconds. `000000020630000R` is relative time format which ignores milliseconds, so the `expected` value should also ignore it.