### PR TITLE
Fix encode PDU regarding data coding

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -318,7 +318,7 @@ filters.time = {
 				value = ('000000000000' + value).substr(-12) + '000R';
 			}
 			return value;
-		} 
+		}
 		if (value instanceof Date) {
 			var result = value.getUTCFullYear().toString().substr(-2);
 			result += ('0' + (value.getUTCMonth() + 1)).substr(-2);
@@ -370,11 +370,21 @@ filters.message = {
 		}
 		var message = typeof value == 'string' ? value : value.message;
 		if (typeof message == 'string') {
-			var encoding = encodings.detect(message);
-			if (message && this.data_coding === null) {
-				this.data_coding = consts.ENCODING[encoding];
+			if (message) {
+				var encoding = encodings.default;
+				if (this.data_coding === null) {
+					encoding = encodings.detect(message);
+					this.data_coding = consts.ENCODING[encoding];
+				} else {
+					for (var key in consts.ENCODING) {
+						if (consts.ENCODING[key] === this.data_coding) {
+							encoding = key;
+							break;
+						}
+					}
+				}
+				message = encodings[encoding].encode(message);
 			}
-			message = encodings[encoding].encode(message);
 		}
 		if (!value.udh || !value.udh.length) {
 			return message;


### PR DESCRIPTION
Solve problem when data_coding set to 0, but `encodings.detect()` returns ASCII.