### PR TITLE
Update of devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,10 @@ node_js:
   - '4'
   - '5'
   - '6'
+  - '7'
+  - '8'
+  - '9'
+  - '10'
+  - '11'
 script: "npm run-script cover"
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -1,4 +1,5 @@
-var iconv = require('iconv-lite');
+var iconv = require('iconv-lite'),
+    utils = require('./utils');
 
 var types = {
 	int8: {
@@ -48,7 +49,7 @@ var types = {
 		write: function(value, buffer, offset) {
 			buffer.writeUInt8(value.length, offset++);
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = utils.Buffer(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
@@ -67,7 +68,7 @@ var types = {
 		},
 		write: function(value, buffer, offset) {
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = utils.Buffer(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 			buffer[offset + value.length] = 0;
@@ -85,14 +86,14 @@ var types = {
 		write: function(value, buffer, offset) {
 			buffer.writeUInt8(value.length, offset++);
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = utils.Buffer(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
 		size: function(value) {
 			return value.length + 1;
 		},
-		default: new Buffer(0)
+		default: utils.Buffer(0)
 	},
 	dest_address_array: {
 		read: function(buffer, offset) {
@@ -196,7 +197,7 @@ types.tlv = {
 		},
 		write: function(value, buffer, offset) {
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = utils.Buffer(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
@@ -211,7 +212,7 @@ types.tlv = {
 		},
 		write: function(value, buffer, offset) {
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = utils.Buffer(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
@@ -250,7 +251,7 @@ encodings.ASCII = { // GSM 03.38
 		for (var i = 0; i < value.length; i++) {
 			result.push(value[i] in this.charCodes ? this.charCodes[value[i]] : 0x20);
 		}
-		return new Buffer(result);
+		return utils.Buffer(result);
 	},
 	decode: function(value) {
 		var result = '';
@@ -419,7 +420,7 @@ filters.billing_identification = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(value.data.length + 1);
+		var result = utils.Buffer(value.data.length + 1);
 		result.writeUInt8(value.format, 0);
 		value.data.copy(result, 1);
 		return result;
@@ -447,9 +448,9 @@ filters.broadcast_area_identifier = {
 			};
 		}
 		if (typeof value.data == 'string') {
-			value.data = new Buffer(value.data, 'ascii');
+			value.data = utils.Buffer(value.data, 'ascii');
 		}
-		var result = new Buffer(value.data.length + 1);
+		var result = utils.Buffer(value.data.length + 1);
 		result.writeUInt8(value.format, 0);
 		value.data.copy(result, 1);
 		return result;
@@ -474,7 +475,7 @@ filters.broadcast_content_type = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(3);
+		var result = utils.Buffer(3);
 		result.writeUInt8(value.network, 0);
 		result.writeUInt16BE(value.content_type, 1);
 		return result;
@@ -495,7 +496,7 @@ filters.broadcast_frequency_interval = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(3);
+		var result = utils.Buffer(3);
 		result.writeUInt8(value.unit, 0);
 		result.writeUInt16BE(value.interval, 1);
 		return result;
@@ -516,7 +517,7 @@ filters.callback_num = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(value.number.length + 3);
+		var result = utils.Buffer(value.number.length + 3);
 		result.writeUInt8(value.digit_mode || 0, 0);
 		result.writeUInt8(value.ton || 0, 1);
 		result.writeUInt8(value.npi || 0, 2);
@@ -541,10 +542,10 @@ filters.callback_num_atag = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(value.display.length + 1);
+		var result = utils.Buffer(value.display.length + 1);
 		result.writeUInt8(value.encoding, 0);
 		if (typeof value.display == 'string') {
-			value.display = new Buffer(value.display, 'ascii');
+			value.display = utils.Buffer(value.display, 'ascii');
 		}
 		value.display.copy(result, 1);
 		return result;

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -1,4 +1,5 @@
 var defs = require('./defs'),
+    utils = require('./utils'),
     commands = defs.commands,
     commandsById = defs.commandsById,
     tlvs = defs.tlvs,
@@ -145,7 +146,7 @@ PDU.prototype._filter = function(func) {
 };
 
 PDU.prototype._initBuffer = function() {
-	var buffer = new Buffer(this.command_length);
+	var buffer = utils.Buffer(this.command_length);
 	pduHeadParams.forEach(function(key, i) {
 		buffer.writeUInt32BE(this[key], i * 4);
 	}.bind(this));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,42 @@
+function Utils() {
+	/**
+	 * Porting to the Buffer.from() / Buffer.alloc() API
+	 *
+	 * @link https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/
+	 *
+	 * @param string|integer value
+	 * @param string|undefined encoding
+	 * @returns Buffer
+	 */
+	this.Buffer = function (value, encoding) {
+		var buf;
+		if (typeof value === 'number') {
+			if (value == 0) {
+				buf = Buffer.concat([]);
+			} else {
+				if (process.version.indexOf('v0.10.') === 0) {
+					if (Buffer.alloc) {
+						buf = Buffer.alloc(value);
+					} else {
+						buf = new Buffer(value);
+						buf.fill(0);
+					}
+				} else {
+					buf = Buffer.alloc ? Buffer.alloc(value) : new Buffer(value).fill(0);
+				}
+			}
+		} else {
+			if (typeof encoding == 'undefined') {
+				encoding = 'utf8';
+			}
+			if (Buffer.from && Buffer.from !== Uint8Array.from) {
+				buf = Buffer.from(value, encoding);
+			} else {
+				buf = new Buffer(value, encoding);
+			}
+		}
+		return buf;
+	}
+};
+
+module.exports = new Utils();

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "coveralls": "^2.11.9",
-    "istanbul": "^0.4.3",
-    "mocha": "2.x"
+    "coveralls": "~2.11.9",
+    "istanbul": "~0.4.3",
+    "mocha": "~2.x"
   },
   "dependencies": {
     "iconv-lite": "0.x"

--- a/test/encodings.js
+++ b/test/encodings.js
@@ -1,5 +1,6 @@
 var assert = require('assert'),
-    encodings = require('../lib/defs').encodings;
+    encodings = require('../lib/defs').encodings,
+    utils = require('../lib/utils');
 
 describe('encodings', function() {
 	describe('ASCII', function() {
@@ -29,7 +30,7 @@ describe('encodings', function() {
 		describe('#encode', function() {
 			it('should properly encode the given string using GSM 03.38 ASCII charset', function() {
 				for(var str in samples) {
-					assert.deepEqual(ASCII.encode(str), new Buffer(samples[str]));
+					assert.deepEqual(ASCII.encode(str), new utils.Buffer(samples[str]));
 				}
 			});
 		});
@@ -66,7 +67,7 @@ describe('encodings', function() {
 		describe('#encode', function() {
 			it('should properly encode the given string using LATIN1 charset', function() {
 				for(var str in samples) {
-					assert.deepEqual(LATIN1.encode(str), new Buffer(samples[str]));
+					assert.deepEqual(LATIN1.encode(str), new utils.Buffer(samples[str]));
 				}
 			});
 		});
@@ -100,7 +101,7 @@ describe('encodings', function() {
 		describe('#encode', function() {
 			it('should properly encode the given string using UCS2 charset', function() {
 				for(var str in samples) {
-					assert.deepEqual(UCS2.encode(str), new Buffer(samples[str]));
+					assert.deepEqual(UCS2.encode(str), new utils.Buffer(samples[str]));
 				}
 			});
 		});

--- a/test/filters.js
+++ b/test/filters.js
@@ -1,5 +1,6 @@
 var assert = require('assert'),
-    filters = require('../lib/defs').filters;
+    filters = require('../lib/defs').filters,
+    utils = require('../lib/utils');
 
 describe('time', function() {
 	var pdu = {};
@@ -35,8 +36,8 @@ describe('message', function() {
 	};
 	var value = 'This is a Test';
 	var value2 = {message: 'This is a Test'};
-	var value3 = {message: new Buffer('This is a Test')};
-	var encoded = new Buffer(value);
+	var value3 = {message: utils.Buffer('This is a Test')};
+	var encoded = utils.Buffer(value);
 	describe('#encode()', function() {
 		it('should encode a high-level formatted short message to a low-level buffer', function() {
 			assert.deepEqual(filters.message.encode.call(pdu, value), encoded);

--- a/test/pdu.js
+++ b/test/pdu.js
@@ -1,12 +1,13 @@
 var assert = require('assert'),
     stream = require('stream'),
-    PDU = require('../lib/pdu').PDU;
+    PDU = require('../lib/pdu').PDU,
+    utils = require('../lib/utils');
 
 describe('PDU', function() {
 	var buffer, expected;
 
 	beforeEach(function() {
-		buffer = new Buffer('0000003b000000040000000000000002' +
+		buffer = utils.Buffer('0000003b000000040000000000000002' +
 			'00010034363730313133333131310001013436373039373' +
 			'731333337000000000000000001000474657374', 'hex');
 		expected = {
@@ -43,7 +44,7 @@ describe('PDU', function() {
 		});
 
 		it('should extract tlv parameters if available', function() {
-			var b = Buffer.concat([buffer, Buffer('0424000474657374', 'hex')]);
+			var b = Buffer.concat([buffer, utils.Buffer('0424000474657374', 'hex')]);
 			b[3] = 67;
 			expected.command_length = 67;
 			expected.message_payload = { message: 'test' };
@@ -52,7 +53,7 @@ describe('PDU', function() {
 		});
 
 		it('should not fail with a malformed pdu', function() {
-			var b = Buffer.concat([buffer, Buffer([0])]);
+			var b = Buffer.concat([buffer, utils.Buffer([0])]);
 			b[3] = 0x3c;
 			expected.command_length = 60;
 			var pdu = new PDU(b);

--- a/test/types.js
+++ b/test/types.js
@@ -1,8 +1,9 @@
 var assert = require('assert'),
-    types = require('../lib/defs').types;
+    types = require('../lib/defs').types,
+    utils = require('../lib/utils');
 
 describe('int8', function() {
-	var b = new Buffer([0, 0x65]), expected = 0x65;
+	var b = utils.Buffer([0, 0x65]), expected = 0x65;
 
 	describe('#read()', function() {
 		it('should read one byte as integer', function() {
@@ -20,13 +21,13 @@ describe('int8', function() {
 	describe('#write()', function() {
 		it('should write one byte to the buffer', function() {
 			types.int8.write(expected, b, 0);
-			assert.deepEqual(new Buffer([0x65]), b.slice(0, 1));
+			assert.deepEqual(utils.Buffer([0x65]), b.slice(0, 1));
 		});
 	});
 });
 
 describe('int16', function() {
-	var b = new Buffer([0, 0x05, 0x65]), expected = 0x0565;
+	var b = utils.Buffer([0, 0x05, 0x65]), expected = 0x0565;
 
 	describe('#read()', function() {
 		it('should read 2 bytes as integer', function() {
@@ -44,13 +45,13 @@ describe('int16', function() {
 	describe('#write()', function() {
 		it('should write 2 bytes to the buffer', function() {
 			types.int16.write(expected, b, 0);
-			assert.deepEqual(new Buffer([0x05, 0x65]), b.slice(0, 2));
+			assert.deepEqual(utils.Buffer([0x05, 0x65]), b.slice(0, 2));
 		});
 	});
 });
 
 describe('int32', function() {
-	var b = new Buffer([0, 0x10, 0x02, 0x40, 0x45]), expected = 0x10024045;
+	var b = utils.Buffer([0, 0x10, 0x02, 0x40, 0x45]), expected = 0x10024045;
 
 	describe('#read()', function() {
 		it('should read 4 bytes as integer', function() {
@@ -68,13 +69,13 @@ describe('int32', function() {
 	describe('#write()', function() {
 		it('should write 4 bytes to the buffer', function() {
 			types.int32.write(expected, b, 0);
-			assert.deepEqual(new Buffer([0x10, 0x02, 0x40, 0x45]), b.slice(0, 4));
+			assert.deepEqual(utils.Buffer([0x10, 0x02, 0x40, 0x45]), b.slice(0, 4));
 		});
 	});
 });
 
 describe('string', function() {
-	var b = new Buffer(9), expected = 'abcd1234';
+	var b = utils.Buffer(9), expected = 'abcd1234';
 	b[0] = 8;
 	b.write(expected, 1);
 
@@ -93,7 +94,7 @@ describe('string', function() {
 
 	describe('#write()', function() {
 		it('should write an Octet String to the buffer', function() {
-			var b2 = new Buffer(9);
+			var b2 = utils.Buffer(9);
 			types.string.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -101,7 +102,7 @@ describe('string', function() {
 });
 
 describe('cstring', function() {
-	var b = new Buffer(9), expected = 'abcd1234';
+	var b = utils.Buffer(9), expected = 'abcd1234';
 	b[8] = 0;
 	b.write(expected, 0);
 
@@ -120,7 +121,7 @@ describe('cstring', function() {
 
 	describe('#write()', function() {
 		it('should write a C-Octet String (null-terminated string) to the buffer', function() {
-			var b2 = new Buffer(9);
+			var b2 = utils.Buffer(9);
 			types.cstring.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -128,7 +129,7 @@ describe('cstring', function() {
 });
 
 describe('buffer', function() {
-	var b = new Buffer(9), expected = new Buffer('abcd1234');
+	var b = utils.Buffer(9), expected = utils.Buffer('abcd1234');
 	b[0] = 8;
 	b.write(expected.toString(), 1);
 
@@ -147,7 +148,7 @@ describe('buffer', function() {
 
 	describe('#write()', function() {
 		it('should write a binary field to the buffer', function() {
-			var b2 = new Buffer(9);
+			var b2 = utils.Buffer(9);
 			types.buffer.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -155,7 +156,7 @@ describe('buffer', function() {
 });
 
 describe('dest_address_array', function() {
-	var b = new Buffer([
+	var b = utils.Buffer([
 		0x02, 0x01, 0x01, 0x02, 0x31, 0x32, 0x33, 0x00,
 		0x02, 0x61, 0x62, 0x63, 0x00
 	]);
@@ -183,7 +184,7 @@ describe('dest_address_array', function() {
 
 	describe('#write()', function() {
 		it('should write an array of dest_address structures to the buffer', function() {
-			var b2 = new Buffer(13);
+			var b2 = utils.Buffer(13);
 			types.dest_address_array.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -191,7 +192,7 @@ describe('dest_address_array', function() {
 });
 
 describe('unsuccess_sme_array', function() {
-	var b = new Buffer([
+	var b = utils.Buffer([
 		0x02, 0x03, 0x04, 0x61, 0x62, 0x63, 0x00, 0x00, 0x00, 0x00, 0x07,
 		0x05, 0x06, 0x31, 0x32, 0x33, 0x00, 0x10, 0x00, 0x00, 0x08
 	]);
@@ -225,7 +226,7 @@ describe('unsuccess_sme_array', function() {
 
 	describe('#write()', function() {
 		it('should write an array of unsuccess_sme structures to the buffer', function() {
-			var b2 = new Buffer(21);
+			var b2 = utils.Buffer(21);
 			types.unsuccess_sme_array.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,36 @@
+var assert = require('assert'),
+	utils = require('../lib/utils');
+
+var version = parseFloat(process.version.replace('v', '')),
+	runTest = true;
+if (version < 5.10) {
+	/**
+	 * Buffer.alloc / Buffer.allocUnsafe / Buffer.from were added just in v5.10.0
+	 * @type {boolean}
+	 */
+	runTest = false;
+}
+
+describe('Utils', function() {
+	describe('Buffer()', function() {
+		if (!runTest) {
+			return;
+		}
+
+		it('Utils.Buffer() should be same as Buffer.alloc()', function() {
+			assert.deepEqual(utils.Buffer(0), Buffer.alloc(0));
+			assert.deepEqual(utils.Buffer(12345), Buffer.alloc(12345));
+		});
+
+		it('Utils.Buffer() should be same as Buffer.allocUnsafe()', function() {
+			assert.deepEqual(utils.Buffer(0), Buffer.allocUnsafe(0));
+		});
+
+		it('Utils.Buffer() should be same as Buffer.from()', function() {
+			assert.deepEqual(utils.Buffer('abcdefg'), Buffer.from('abcdefg'));
+			assert.deepEqual(utils.Buffer('abcdefg', 'ascii'), Buffer.from('abcdefg', 'ascii'));
+			assert.deepEqual(utils.Buffer('ąčęėįšųž', 'utf8'), Buffer.from('ąčęėįšųž', 'utf8'));
+			assert.deepEqual(utils.Buffer([1, 2, 3, 5000]), Buffer.from([1, 2, 3, 5000]));
+		});
+	});
+});


### PR DESCRIPTION
Update of `devDependencies` by preserving backward compatability of older Node / npm versions.

Introduced custom wrapper `Utils.Buffer()` for handling breaking changes of obsolete `new Buffer()` constructor, otherwise error will keep occuring like:
> (node:XXX) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

According to [nodejs.org guide](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) how to port it, I've chosen [Version 3](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-3) because:
- `Version 1` drops backward compatability of older Node / npm versions
- `Version 2` would still allow throwing `DeprecationWarning` warning