### PR TITLE
Porting to the Buffer.from()/Buffer.alloc()

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -1,4 +1,5 @@
-var iconv = require('iconv-lite');
+var iconv = require('iconv-lite'),
+	Buffer = require('safer-buffer').Buffer;
 
 var types = {
 	int8: {
@@ -48,7 +49,7 @@ var types = {
 		write: function(value, buffer, offset) {
 			buffer.writeUInt8(value.length, offset++);
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = Buffer.from(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
@@ -67,7 +68,7 @@ var types = {
 		},
 		write: function(value, buffer, offset) {
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = Buffer.from(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 			buffer[offset + value.length] = 0;
@@ -85,14 +86,14 @@ var types = {
 		write: function(value, buffer, offset) {
 			buffer.writeUInt8(value.length, offset++);
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = Buffer.from(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
 		size: function(value) {
 			return value.length + 1;
 		},
-		default: new Buffer(0)
+		default: Buffer.alloc(0)
 	},
 	dest_address_array: {
 		read: function(buffer, offset) {
@@ -196,7 +197,7 @@ types.tlv = {
 		},
 		write: function(value, buffer, offset) {
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = Buffer.from(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
@@ -211,7 +212,7 @@ types.tlv = {
 		},
 		write: function(value, buffer, offset) {
 			if (typeof value == 'string') {
-				value = new Buffer(value, 'ascii');
+				value = Buffer.from(value, 'ascii');
 			}
 			value.copy(buffer, offset);
 		},
@@ -250,7 +251,7 @@ encodings.ASCII = { // GSM 03.38
 		for (var i = 0; i < value.length; i++) {
 			result.push(value[i] in this.charCodes ? this.charCodes[value[i]] : 0x20);
 		}
-		return new Buffer(result);
+		return Buffer.from(result);
 	},
 	decode: function(value) {
 		var result = '';
@@ -318,7 +319,7 @@ filters.time = {
 				value = ('000000000000' + value).substr(-12) + '000R';
 			}
 			return value;
-		} 
+		}
 		if (value instanceof Date) {
 			var result = value.getUTCFullYear().toString().substr(-2);
 			result += ('0' + (value.getUTCMonth() + 1)).substr(-2);
@@ -419,7 +420,7 @@ filters.billing_identification = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(value.data.length + 1);
+		var result = Buffer.alloc(value.data.length + 1);
 		result.writeUInt8(value.format, 0);
 		value.data.copy(result, 1);
 		return result;
@@ -447,9 +448,9 @@ filters.broadcast_area_identifier = {
 			};
 		}
 		if (typeof value.data == 'string') {
-			value.data = new Buffer(value.data, 'ascii');
+			value.data = Buffer.from(value.data, 'ascii');
 		}
-		var result = new Buffer(value.data.length + 1);
+		var result = Buffer.alloc(value.data.length + 1);
 		result.writeUInt8(value.format, 0);
 		value.data.copy(result, 1);
 		return result;
@@ -474,7 +475,7 @@ filters.broadcast_content_type = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(3);
+		var result = Buffer.alloc(3);
 		result.writeUInt8(value.network, 0);
 		result.writeUInt16BE(value.content_type, 1);
 		return result;
@@ -495,7 +496,7 @@ filters.broadcast_frequency_interval = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(3);
+		var result = Buffer.alloc(3);
 		result.writeUInt8(value.unit, 0);
 		result.writeUInt16BE(value.interval, 1);
 		return result;
@@ -516,7 +517,7 @@ filters.callback_num = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(value.number.length + 3);
+		var result = Buffer.alloc(value.number.length + 3);
 		result.writeUInt8(value.digit_mode || 0, 0);
 		result.writeUInt8(value.ton || 0, 1);
 		result.writeUInt8(value.npi || 0, 2);
@@ -541,10 +542,10 @@ filters.callback_num_atag = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var result = new Buffer(value.display.length + 1);
+		var result = Buffer.alloc(value.display.length + 1);
 		result.writeUInt8(value.encoding, 0);
 		if (typeof value.display == 'string') {
-			value.display = new Buffer(value.display, 'ascii');
+			value.display = Buffer.from(value.display, 'ascii');
 		}
 		value.display.copy(result, 1);
 		return result;

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -1,8 +1,9 @@
 var defs = require('./defs'),
-    commands = defs.commands,
-    commandsById = defs.commandsById,
-    tlvs = defs.tlvs,
-    tlvsById = defs.tlvsById;
+	commands = defs.commands,
+	commandsById = defs.commandsById,
+	tlvs = defs.tlvs,
+	tlvsById = defs.tlvsById,
+	Buffer = require('safer-buffer').Buffer;
 
 var pduHeadParams = [
 	'command_length',
@@ -145,7 +146,7 @@ PDU.prototype._filter = function(func) {
 };
 
 PDU.prototype._initBuffer = function() {
-	var buffer = new Buffer(this.command_length);
+	var buffer = Buffer.alloc(this.command_length);
 	pduHeadParams.forEach(function(key, i) {
 		buffer.writeUInt32BE(this[key], i * 4);
 	}.bind(this));

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mocha": "2.x"
   },
   "dependencies": {
-    "iconv-lite": "0.x"
+    "iconv-lite": "0.x",
+    "safer-buffer": ">= 2.1.2 < 3"
   }
 }

--- a/test/encodings.js
+++ b/test/encodings.js
@@ -1,5 +1,6 @@
 var assert = require('assert'),
-    encodings = require('../lib/defs').encodings;
+	encodings = require('../lib/defs').encodings,
+	Buffer = require('safer-buffer').Buffer;
 
 describe('encodings', function() {
 	describe('ASCII', function() {
@@ -29,7 +30,7 @@ describe('encodings', function() {
 		describe('#encode', function() {
 			it('should properly encode the given string using GSM 03.38 ASCII charset', function() {
 				for(var str in samples) {
-					assert.deepEqual(ASCII.encode(str), new Buffer(samples[str]));
+					assert.deepEqual(ASCII.encode(str), Buffer.from(samples[str]));
 				}
 			});
 		});
@@ -66,7 +67,7 @@ describe('encodings', function() {
 		describe('#encode', function() {
 			it('should properly encode the given string using LATIN1 charset', function() {
 				for(var str in samples) {
-					assert.deepEqual(LATIN1.encode(str), new Buffer(samples[str]));
+					assert.deepEqual(LATIN1.encode(str), Buffer.from(samples[str]));
 				}
 			});
 		});
@@ -100,7 +101,7 @@ describe('encodings', function() {
 		describe('#encode', function() {
 			it('should properly encode the given string using UCS2 charset', function() {
 				for(var str in samples) {
-					assert.deepEqual(UCS2.encode(str), new Buffer(samples[str]));
+					assert.deepEqual(UCS2.encode(str), Buffer.from(samples[str]));
 				}
 			});
 		});

--- a/test/filters.js
+++ b/test/filters.js
@@ -1,5 +1,6 @@
 var assert = require('assert'),
-    filters = require('../lib/defs').filters;
+	filters = require('../lib/defs').filters,
+	Buffer = require('safer-buffer').Buffer;
 
 describe('time', function() {
 	var pdu = {};
@@ -35,8 +36,8 @@ describe('message', function() {
 	};
 	var value = 'This is a Test';
 	var value2 = {message: 'This is a Test'};
-	var value3 = {message: new Buffer('This is a Test')};
-	var encoded = new Buffer(value);
+	var value3 = {message: Buffer.from('This is a Test')};
+	var encoded = Buffer.from(value);
 	describe('#encode()', function() {
 		it('should encode a high-level formatted short message to a low-level buffer', function() {
 			assert.deepEqual(filters.message.encode.call(pdu, value), encoded);

--- a/test/pdu.js
+++ b/test/pdu.js
@@ -1,12 +1,13 @@
 var assert = require('assert'),
-    stream = require('stream'),
-    PDU = require('../lib/pdu').PDU;
+	stream = require('stream'),
+	PDU = require('../lib/pdu').PDU,
+	Buffer = require('safer-buffer').Buffer;
 
 describe('PDU', function() {
 	var buffer, expected;
 
 	beforeEach(function() {
-		buffer = new Buffer('0000003b000000040000000000000002' +
+		buffer = Buffer.from('0000003b000000040000000000000002' +
 			'00010034363730313133333131310001013436373039373' +
 			'731333337000000000000000001000474657374', 'hex');
 		expected = {
@@ -43,7 +44,7 @@ describe('PDU', function() {
 		});
 
 		it('should extract tlv parameters if available', function() {
-			var b = Buffer.concat([buffer, Buffer('0424000474657374', 'hex')]);
+			var b = Buffer.concat([buffer, Buffer.from('0424000474657374', 'hex')]);
 			b[3] = 67;
 			expected.command_length = 67;
 			expected.message_payload = { message: 'test' };
@@ -52,7 +53,7 @@ describe('PDU', function() {
 		});
 
 		it('should not fail with a malformed pdu', function() {
-			var b = Buffer.concat([buffer, Buffer([0])]);
+			var b = Buffer.concat([buffer, Buffer.from([0])]);
 			b[3] = 0x3c;
 			expected.command_length = 60;
 			var pdu = new PDU(b);

--- a/test/types.js
+++ b/test/types.js
@@ -1,8 +1,9 @@
 var assert = require('assert'),
-    types = require('../lib/defs').types;
+	types = require('../lib/defs').types,
+	Buffer = require('safer-buffer').Buffer;
 
 describe('int8', function() {
-	var b = new Buffer([0, 0x65]), expected = 0x65;
+	var b = Buffer.from([0, 0x65]), expected = 0x65;
 
 	describe('#read()', function() {
 		it('should read one byte as integer', function() {
@@ -20,13 +21,13 @@ describe('int8', function() {
 	describe('#write()', function() {
 		it('should write one byte to the buffer', function() {
 			types.int8.write(expected, b, 0);
-			assert.deepEqual(new Buffer([0x65]), b.slice(0, 1));
+			assert.deepEqual(Buffer.from([0x65]), b.slice(0, 1));
 		});
 	});
 });
 
 describe('int16', function() {
-	var b = new Buffer([0, 0x05, 0x65]), expected = 0x0565;
+	var b = Buffer.from([0, 0x05, 0x65]), expected = 0x0565;
 
 	describe('#read()', function() {
 		it('should read 2 bytes as integer', function() {
@@ -44,13 +45,13 @@ describe('int16', function() {
 	describe('#write()', function() {
 		it('should write 2 bytes to the buffer', function() {
 			types.int16.write(expected, b, 0);
-			assert.deepEqual(new Buffer([0x05, 0x65]), b.slice(0, 2));
+			assert.deepEqual(Buffer.from([0x05, 0x65]), b.slice(0, 2));
 		});
 	});
 });
 
 describe('int32', function() {
-	var b = new Buffer([0, 0x10, 0x02, 0x40, 0x45]), expected = 0x10024045;
+	var b = Buffer.from([0, 0x10, 0x02, 0x40, 0x45]), expected = 0x10024045;
 
 	describe('#read()', function() {
 		it('should read 4 bytes as integer', function() {
@@ -68,13 +69,13 @@ describe('int32', function() {
 	describe('#write()', function() {
 		it('should write 4 bytes to the buffer', function() {
 			types.int32.write(expected, b, 0);
-			assert.deepEqual(new Buffer([0x10, 0x02, 0x40, 0x45]), b.slice(0, 4));
+			assert.deepEqual(Buffer.from([0x10, 0x02, 0x40, 0x45]), b.slice(0, 4));
 		});
 	});
 });
 
 describe('string', function() {
-	var b = new Buffer(9), expected = 'abcd1234';
+	var b = Buffer.alloc(9), expected = 'abcd1234';
 	b[0] = 8;
 	b.write(expected, 1);
 
@@ -93,7 +94,7 @@ describe('string', function() {
 
 	describe('#write()', function() {
 		it('should write an Octet String to the buffer', function() {
-			var b2 = new Buffer(9);
+			var b2 = Buffer.alloc(9);
 			types.string.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -101,7 +102,7 @@ describe('string', function() {
 });
 
 describe('cstring', function() {
-	var b = new Buffer(9), expected = 'abcd1234';
+	var b = Buffer.alloc(9), expected = 'abcd1234';
 	b[8] = 0;
 	b.write(expected, 0);
 
@@ -120,7 +121,7 @@ describe('cstring', function() {
 
 	describe('#write()', function() {
 		it('should write a C-Octet String (null-terminated string) to the buffer', function() {
-			var b2 = new Buffer(9);
+			var b2 = Buffer.alloc(9);
 			types.cstring.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -128,7 +129,7 @@ describe('cstring', function() {
 });
 
 describe('buffer', function() {
-	var b = new Buffer(9), expected = new Buffer('abcd1234');
+	var b = Buffer.alloc(9), expected = Buffer.from('abcd1234');
 	b[0] = 8;
 	b.write(expected.toString(), 1);
 
@@ -147,7 +148,7 @@ describe('buffer', function() {
 
 	describe('#write()', function() {
 		it('should write a binary field to the buffer', function() {
-			var b2 = new Buffer(9);
+			var b2 = Buffer.alloc(9);
 			types.buffer.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -155,7 +156,7 @@ describe('buffer', function() {
 });
 
 describe('dest_address_array', function() {
-	var b = new Buffer([
+	var b = Buffer.from([
 		0x02, 0x01, 0x01, 0x02, 0x31, 0x32, 0x33, 0x00,
 		0x02, 0x61, 0x62, 0x63, 0x00
 	]);
@@ -183,7 +184,7 @@ describe('dest_address_array', function() {
 
 	describe('#write()', function() {
 		it('should write an array of dest_address structures to the buffer', function() {
-			var b2 = new Buffer(13);
+			var b2 = Buffer.alloc(13);
 			types.dest_address_array.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});
@@ -191,7 +192,7 @@ describe('dest_address_array', function() {
 });
 
 describe('unsuccess_sme_array', function() {
-	var b = new Buffer([
+	var b = Buffer.from([
 		0x02, 0x03, 0x04, 0x61, 0x62, 0x63, 0x00, 0x00, 0x00, 0x00, 0x07,
 		0x05, 0x06, 0x31, 0x32, 0x33, 0x00, 0x10, 0x00, 0x00, 0x08
 	]);
@@ -225,7 +226,7 @@ describe('unsuccess_sme_array', function() {
 
 	describe('#write()', function() {
 		it('should write an array of unsuccess_sme structures to the buffer', function() {
-			var b2 = new Buffer(21);
+			var b2 = Buffer.alloc(21);
 			types.unsuccess_sme_array.write(expected, b2, 0);
 			assert.deepEqual(b, b2);
 		});


### PR DESCRIPTION
The propose of this PR is to move from deprecated and unsafe Buffer() and new Buffer() constructors to safer Buffer.from()/Buffer.alloc().

In order to keep support for Node versions <6, [safer-buffer](https://www.npmjs.com/package/safer-buffer) polyfill was added. safer-buffer was already a dependency from iconv-lite.

The guidelines used for these changes are described Node porting guide [Variant 1](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1) and [Variant 2](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-2)

Later, when old Node versions support is no longer required or not possible to support, all that is required is to remove the safer-buffer polyfill and dependency.

Changes where tested with and without polyfill.