### PR TITLE
Support GSM language shift tables

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -514,7 +514,7 @@ filters.message = {
 					var udh = udhList[i];
 					if (udh[0] === 0x24 || udh[0] === 0x25) {
 						this.data_coding = consts.ENCODING.ASCII;
-						message = gsmCoder.encode(message, value.udh[2]);
+						message = gsmCoder.encode(message, udh[2]);
 						encoded = true;
 						break;
 					}

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -222,49 +222,139 @@ types.tlv = {
 	}
 };
 
-var encodings = {};
-
-encodings.ASCII = { // GSM 03.38
-	chars: '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
-	charCodes: {},
-	extChars: {},
-	regex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
-	init: function() {
-		for (var i = 0; i < this.chars.length; i++) {
-			this.charCodes[this.chars[i]] = i;
-		}
-		var from = '\f^{}\\[~]|€', to = '\nΛ()/<=>¡e';
-		for (var i = 0; i < from.length; i++) {
-			this.extChars[from[i]] = to[i];
-			this.extChars[to[i]] = from[i];
-		}
+var gsmCoder = {
+	// GSM 03.38
+	GSM: {
+		chars: '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+		extChars: '\f^{}\\[~]|€',
+		escChars: '\nΛ()/<=>¡e',
+		charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,\-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüà\f^{}\\[~\]|€]*$/,
+		charListEnc: {},
+		extCharListEnc: {},
+		charListDec: {},
+		extCharListDec: {}
 	},
-	match: function(value) {
-		return this.regex.test(value);
+	// GSM 03.38 Turkish Shift Table
+	GSM_TR: {
+		chars: '@£$¥€éùıòÇ\nĞğ\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BŞşßÉ !"#¤%&\'()*+,-./0123456789:;<=>?İABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§çabcdefghijklmnopqrstuvwxyzäöñüà',
+		extCharsEnc: '\f^{}\\[~]|',
+		escCharsEnc: '\nΛ()/<=>İ',
+		extCharsDec: '\f{}^\\[~]|ĞİŞç€ğış',
+		escCharsDec: '\n()Λ/<=>İGIScegis',
+		charRegex: /^[@£$¥€éùıòÇ\nĞğ\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BŞşßÉ !"#¤%&\'()*+,-./0-9:;<=>?İA-ZÄÖÑÜ§ça-zäöñüà\f^{}\\[~\]|ĞİŞç€ğış]*$/,
+		charListEnc: {},
+		extCharListEnc: {},
+		charListDec: {},
+		extCharListDec: {}
 	},
-	encode: function(value) {
-		var result = [];
-		value = value.replace(/[\f^{}\\[~\]|€]/g, function(match) {
-			return '\x1B' + this.extChars[match];
-		}.bind(this));
-		for (var i = 0; i < value.length; i++) {
-			result.push(value[i] in this.charCodes ? this.charCodes[value[i]] : 0x20);
-		}
-		return new Buffer(result);
+	// GSM 03.38 Spanish Shift Table
+	GSM_ES: {
+		chars: '@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà',
+		extChars: 'ç\f^{}\\[~]|ÁÍÓÚá€íóú',
+		escChars: 'Ç\nΛ()/<=>¡AIOUaeiou',
+		charRegex: /^[@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\'()*+,-./0-9:;<=>?¡A-ZÄÖÑÜ§¿a-zäöñüàç\f^{}\\[~\]|ÁÍÓÚá€íóú]*$/,
+		charListEnc: {},
+		extCharListEnc: {},
+		charListDec: {},
+		extCharListDec: {}
 	},
-	decode: function(value) {
-		var result = '';
-		for (var i = 0; i < value.length; i++) {
-			result += this.chars[value[i]] || ' ';
-		}
-		result = result.replace(/\x1B([\nΛ()\/<=>¡e])/g, function(match, p1) {
-			return this.extChars[p1];
-		}.bind(this));
-		return result;
+	// GSM 03.38 Portuguese Shift Table
+	GSM_PT: {
+		chars: '@£$¥êéúíóç\nÔô\rÁáΔ_ªÇÀ∞^\\€Ó|\x1BÂâÊÉ !"#º%&\'()*+,-./0123456789:;<=>?ÍABCDEFGHIJKLMNOPQRSTUVWXYZÃÕÚÜ§~abcdefghijklmnopqrstuvwxyzãõ`üà',
+		extCharsEnc: '\fΦΓ^ΩΠΨΣΘ{}\\[~]|',
+		escCharsEnc: '\nªÇÀ∞^\\€Ó()/<=>Í',
+		extCharsDec: 'êç\fÔôÁáΦΓ^ΩΠΨΣΘÊ{}\\[~]|ÀÍÓÚÃÕÂ€íóúãõâ',
+		escCharsDec: 'éç\nÔôÁáªÇÀ∞^\\€ÓÉ()/<=>ÍAIOUÃÕaeiouãõà',
+		charRegex: /^[@£$¥êéúíóç\nÔô\rÁáΔ_ªÇÀ∞^\\€Ó|\x1BÂâÊÉ !"#º%&\'()*+,-./0-9:;<=>?ÍA-ZÃÕÚÜ§~a-zãõ`üàêç\fÔôÁáΦΓ^ΩΠΨΣΘÊ{}\\[~\]|ÀÍÓÚÃÕÂ€íóúãõâ]*$/,
+		charListEnc: {},
+		extCharListEnc: {},
+		charListDec: {},
+		extCharListDec: {}
 	}
 };
 
-encodings.ASCII.init();
+gsmCoder.getCoder = function(encoding) {
+	var coder = this.GSM;
+	switch (encoding) {
+		case 0x01:
+			coder = this.GSM_TR;
+			break;
+		case 0x02:
+			coder = this.GSM_ES;
+			break;
+		case 0x03:
+			coder = this.GSM_PT;
+			break;
+	}
+
+	if (Object.keys(coder.charListEnc).length === 0) {
+		for (var i = 0; i < coder.chars.length; i++) {
+			coder.charListEnc[coder.chars[i]] = i;
+			coder.charListDec[i] = coder.chars[i];
+		}
+
+		var extCharsEnc = coder.extCharsEnc || coder.extChars;
+		var escCharsEnc = coder.escCharsEnc || coder.escChars;
+		for (var i = 0; i < extCharsEnc.length; i++) {
+			coder.extCharListEnc[extCharsEnc[i]] = escCharsEnc[i];
+		}
+
+		var extCharsDec = coder.extCharsDec || coder.extChars;
+		var escCharsDec = coder.escCharsDec || coder.escChars;
+		for (var i = 0; i < escCharsDec.length; i++) {
+			coder.extCharListDec[escCharsDec[i]] = extCharsDec[i];
+		}
+	}
+
+	return coder;
+}
+
+gsmCoder.encode = function(string, encoding) {
+	var coder = this.getCoder(encoding);
+	var extCharsEnc = coder.extCharsEnc || coder.extChars;
+	var extCharRegex = new RegExp('[' + extCharsEnc.replace(']', '\\]') + ']', 'g');
+
+	string = string.replace(extCharRegex, function(match) {
+		return '\x1B' + coder.extCharListEnc[match];
+	});
+
+	var result = [];
+
+	for (var i = 0; i < string.length; i++) {
+		result.push(string[i] in coder.charListEnc ? coder.charListEnc[string[i]] : '\x20');
+	}
+
+	return new Buffer(result);
+};
+
+gsmCoder.decode = function (string, encoding) {
+	var coder = this.getCoder(encoding);
+	var escCharsDec = coder.escCharsDec || coder.escChars;
+	var escCharRegex = new RegExp('\x1B([' + escCharsDec + '])', 'g');
+	var result = '';
+
+	for (var i = 0; i < string.length; i++) {
+		result += coder.charListDec[string[i]] || ' ';
+	}
+
+	return result.replace(escCharRegex, function(match, p1) {
+		return coder.extCharListDec[p1];
+	});
+  };
+
+var encodings = {};
+
+encodings.ASCII = { // GSM 03.38
+	match: function(value) {
+		return gsmCoder.GSM.charRegex.test(value);
+	},
+	encode: function(value) {
+		return gsmCoder.encode(value, 0x00);
+	},
+	decode: function(value) {
+		return gsmCoder.decode(value, 0x00);
+	}
+}
 
 encodings.LATIN1 = {
 	match: function(value) {
@@ -318,7 +408,7 @@ filters.time = {
 				value = ('000000000000' + value).substr(-12) + '000R';
 			}
 			return value;
-		} 
+		}
 		if (value instanceof Date) {
 			var result = value.getUTCFullYear().toString().substr(-2);
 			result += ('0' + (value.getUTCMonth() + 1)).substr(-2);
@@ -370,11 +460,16 @@ filters.message = {
 		}
 		var message = typeof value == 'string' ? value : value.message;
 		if (typeof message == 'string') {
-			var encoding = encodings.detect(message);
-			if (message && this.data_coding === null) {
-				this.data_coding = consts.ENCODING[encoding];
+			if (value.udh && value.udh[0] === 0x03 && (value.udh[1] === 0x24 || value.udh[1] === 0x25)) {
+				this.data_coding = consts.ENCODING.ASCII;
+				message = gsmCoder.encode(message, value.udh[3]);
+ 			} else {
+				var encoding = encodings.detect(message);
+				if (message && this.data_coding === null) {
+					this.data_coding = consts.ENCODING[encoding];
+				}
+				message = encodings[encoding].encode(message);
 			}
-			message = encodings[encoding].encode(message);
 		}
 		if (!value.udh || !value.udh.length) {
 			return message;
@@ -384,7 +479,7 @@ filters.message = {
 		}
 		return Buffer.concat([value.udh, message]);
 	},
-	decode: function(value) {
+	decode: function(value, skipUdh) {
 		if (!Buffer.isBuffer(value) || !('data_coding' in this)) {
 			return value;
 		}
@@ -401,13 +496,15 @@ filters.message = {
 		}
 		var udhi = this.esm_class & consts.ESM_CLASS.UDH_INDICATOR;
 		var result = {};
-		if (value.length && udhi) {
+		if (!skipUdh && value.length && udhi) {
 			result.udh = value.slice(0, value[0] + 1);
 			result.message = value.slice(value[0] + 1);
 		} else {
 			result.message = value;
 		}
-		if (encodings[encoding]) {
+		if (result.udh && result.udh[0] === 0x03 && (result.udh[1] === 0x24 || result.udh[1] === 0x25)) {
+			result.message = gsmCoder.decode(result.message, result.udh[3]);
+		} else if (encodings[encoding]) {
 			result.message = encodings[encoding].decode(result.message);
 		}
 		return result;
@@ -1211,6 +1308,9 @@ var consts = {
 	ENCODING: {
 		SMSC_DEFAULT:       0x00,
 		ASCII:              0x01,
+		GSM_TR:             0x01,
+		GSM_ES:             0x01,
+		GSM_PT:             0x01,
 		IA5:                0x01,
 		LATIN1:             0x03,
 		ISO_8859_1:         0x03,
@@ -1324,6 +1424,7 @@ exports.errors = {
 
 exports.encodings = encodings;
 exports.filters = filters;
+exports.gsmCoder = gsmCoder;
 exports.consts = consts;
 exports.commands = commands;
 exports.commandsById = commandsById;

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -434,8 +434,8 @@ udhCoder.getUdh = function(buffer) {
 
 	var cursor = 1;
 	do {
-		var udhLength = buffer[cursor + 1] + 3;
-		udhList.push(buffer.slice(cursor, udhLength));
+		var udhLength = buffer[cursor + 1] + 2;
+		udhList.push(buffer.slice(cursor, cursor + udhLength));
 		cursor += udhLength;
 	} while (cursor < bufferLength);
 

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -434,7 +434,7 @@ udhCoder.getUdh = function(buffer) {
 
 	var cursor = 1;
 	do {
-		var udhLength = bufferLength[cursor + 1] + 2;
+		var udhLength = buffer[cursor + 1] + 3;
 		udhList.push(buffer.slice(cursor, udhLength));
 		cursor += udhLength;
 	} while (cursor < bufferLength);

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -461,7 +461,9 @@ filters.message = {
 		var message = typeof value == 'string' ? value : value.message;
 		if (typeof message == 'string') {
 			if (value.udh && value.udh[0] === 0x03 && (value.udh[1] === 0x24 || value.udh[1] === 0x25)) {
-				this.data_coding = consts.ENCODING.ASCII;
+				if (this.data_coding === null) {
+					this.data_coding = consts.ENCODING.ASCII;
+				}
 				message = gsmCoder.encode(message, value.udh[3]);
  			} else {
 				var encoding = encodings.detect(message);

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -416,6 +416,32 @@ Object.defineProperty(encodings, 'default', {
 	writable: true
 });
 
+var udhCoder = {};
+
+/**
+ * @param buffer:Buffer
+ *
+ * @return Array
+ */
+udhCoder.getUdh = function(buffer) {
+	var bufferLength = buffer.length;
+
+	if (bufferLength <= 1) {
+		return [];
+	}
+
+	var udhList = [];
+
+	var cursor = 1;
+	do {
+		var udhLength = bufferLength[cursor + 1] + 2;
+		udhList.push(buffer.slice(cursor, udhLength));
+		cursor += udhLength;
+	} while (cursor < bufferLength);
+
+	return udhList;
+};
+
 var filters = {};
 
 filters.time = {
@@ -516,16 +542,28 @@ filters.message = {
 				}
 			}
 		}
-		var udhi = this.esm_class & consts.ESM_CLASS.UDH_INDICATOR;
+		var udhi = this.esm_class & (consts.ESM_CLASS.UDH_INDICATOR || consts.ESM_CLASS.KANNEL_UDH_INDICATOR);
 		var result = {};
 		if (!skipUdh && value.length && udhi) {
-			result.udh = value.slice(0, value[0] + 1);
+			result.udh = udhCoder.getUdh(value.slice(0, value[0] + 1));
 			result.message = value.slice(value[0] + 1);
 		} else {
 			result.message = value;
 		}
-		if (result.udh && result.udh[0] === 0x03 && (result.udh[1] === 0x24 || result.udh[1] === 0x25)) {
-			result.message = gsmCoder.decode(result.message, result.udh[3]);
+		if (result.udh && (encoding === consts.ENCODING.SMSC_DEFAULT || consts.ENCODING.ASCII)) {
+			var decoded = false;
+			for (var i = 0; i < result.udh.length; i++) {
+				var udh = result.udh[i];
+				if (udh[0] === 0x24 || udh[0] === 0x25) {
+					result.message = gsmCoder.decode(result.message, udh[2]);
+					decoded = true;
+					break;
+				}
+			}
+
+			if (!decoded && encodings[encoding]) {
+				result.message = encodings[encoding].decode(result.message);
+			}
 		} else if (encodings[encoding]) {
 			result.message = encodings[encoding].decode(result.message);
 		}
@@ -1291,6 +1329,7 @@ var consts = {
 		CONVERSATION_ABORT:       0x18,
 		INTERMEDIATE_DELIVERY:    0x20,
 		UDH_INDICATOR:            0x40,
+		KANNEL_UDH_INDICATOR:     0x43,
 		SET_REPLY_PATH:           0x80
 	},
 	MESSAGE_STATE: {

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -307,7 +307,7 @@ gsmCoder.getCoder = function(encoding) {
 	}
 
 	return coder;
-}
+};
 
 gsmCoder.encode = function(string, encoding) {
 	var coder = this.getCoder(encoding);
@@ -340,7 +340,27 @@ gsmCoder.decode = function (string, encoding) {
 	return result.replace(escCharRegex, function(match, p1) {
 		return coder.extCharListDec[p1];
 	});
-  };
+};
+
+gsmCoder.detect = function (string) {
+	if (gsmCoder.GSM_ES.charRegex.test(string)) {
+		return 0x02;
+	}
+
+	if (gsmCoder.GSM_PT.charRegex.test(string)) {
+		return 0x03;
+	}
+
+	if (gsmCoder.GSM_TR.charRegex.test(string)) {
+		return 0x01;
+	}
+
+	if (gsmCoder.GSM.charRegex.test(string)) {
+		return 0x00;
+	}
+
+	return undefined;
+};
 
 var encodings = {};
 
@@ -354,7 +374,7 @@ encodings.ASCII = { // GSM 03.38
 	decode: function(value) {
 		return gsmCoder.decode(value, 0x00);
 	}
-}
+};
 
 encodings.LATIN1 = {
 	match: function(value) {

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -504,15 +504,28 @@ filters.message = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
-		var message = typeof value == 'string' ? value : value.message;
-		if (typeof message == 'string') {
-			if (value.udh && value.udh[0] === 0x03 && (value.udh[1] === 0x24 || value.udh[1] === 0x25)) {
-				if (this.data_coding === null) {
-					this.data_coding = consts.ENCODING.ASCII;
+		var message = typeof value === 'string' ? value : value.message;
+		if (typeof message === 'string') {
+			var encoding = encodings.detect(message);
+			if (value.udh) {
+				var udhList = udhCoder.getUdh(value.udh);
+				var encoded = false;
+				for (var i = 0; i < udhList.length; i++) {
+					var udh = udhList[i];
+					if (udh[0] === 0x24 || udh[0] === 0x25) {
+						this.data_coding = consts.ENCODING.ASCII;
+						message = gsmCoder.encode(message, value.udh[2]);
+						encoded = true;
+						break;
+					}
 				}
-				message = gsmCoder.encode(message, value.udh[3]);
- 			} else {
-				var encoding = encodings.detect(message);
+				if (!encoded) {
+					if (message && this.data_coding === null) {
+						this.data_coding = consts.ENCODING[encoding];
+					}
+					message = encodings[encoding].encode(message);
+				}
+			} else {
 				if (message && this.data_coding === null) {
 					this.data_coding = consts.ENCODING[encoding];
 				}
@@ -560,7 +573,6 @@ filters.message = {
 					break;
 				}
 			}
-
 			if (!decoded && encodings[encoding]) {
 				result.message = encodings[encoding].decode(result.message);
 			}

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -135,10 +135,10 @@ PDU.prototype._filter = function(func) {
 		} else if (tlvs[key] && tlvs[key].filter) {
 			if (tlvs[key].multiple) {
 				this[key].forEach(function(value, i) {
-					 this[key][i] = tlvs[key].filter[func].call(this, value);
+					 this[key][i] = tlvs[key].filter[func].call(this, value, true);
 				}.bind(this));
 			} else {
-				this[key] = tlvs[key].filter[func].call(this, this[key]);
+				this[key] = tlvs[key].filter[func].call(this, this[key], true);
 			}
 		}
 	}

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -138,7 +138,7 @@ PDU.prototype._filter = function(func) {
 					 this[key][i] = tlvs[key].filter[func].call(this, value, true);
 				}.bind(this));
 			} else {
-				this[key] = tlvs[key].filter[func].call(this, this[key], true);
+				this[key] = tlvs[key].filter[func].call(this, this[key], key !== 'message_payload');
 			}
 		}
 	}

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -138,7 +138,11 @@ PDU.prototype._filter = function(func) {
 					 this[key][i] = tlvs[key].filter[func].call(this, value, true);
 				}.bind(this));
 			} else {
-				this[key] = tlvs[key].filter[func].call(this, this[key], key !== 'message_payload');
+				if (key === 'message_payload') {
+					this[key] = tlvs[key].filter[func].call(this, this[key], 'short_message' in this);
+				} else {
+					this[key] = tlvs[key].filter[func].call(this, this[key], key !== 'message_payload');
+				}
 			}
 		}
 	}

--- a/test/encodings.js
+++ b/test/encodings.js
@@ -1,5 +1,6 @@
 var assert = require('assert'),
-    encodings = require('../lib/defs').encodings;
+	encodings = require('../lib/defs').encodings;
+	gsmCoder = require('../lib/defs').gsmCoder;
 
 describe('encodings', function() {
 	describe('ASCII', function() {
@@ -109,6 +110,126 @@ describe('encodings', function() {
 			it('should properly decode the given buffer using UCS2 charset', function() {
 				for(var str in samples) {
 					assert.deepEqual(UCS2.decode(samples[str]), str);
+				}
+			});
+		});
+	});
+
+	describe('GSM_TR', function() {
+		var samples = {
+			'@£$¥': [0, 1, 2, 3],
+			' 1a=': [0x20, 0x31, 0x61, 0x3D],
+			'~^€Ğ': [0x1B, 0x3D, 0x1B, 0x14, 0x04, 0x0B]
+		};
+
+		describe('#match()', function() {
+			it('should return true for strings that can be encoded using GSM 03.38 Turkish Shift Table charset', function() {
+				assert(gsmCoder.GSM_TR.charRegex.test(''));
+				assert(gsmCoder.GSM_TR.charRegex.test('@£$¥€éùıòÇ\nĞğ\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BŞşßÉ !"#¤%&\''));
+				assert(gsmCoder.GSM_TR.charRegex.test('()*+,-./0123456789:;<=>?İABCDEFGHIJKLMNOPQRSTUVWXYZ'));
+				assert(gsmCoder.GSM_TR.charRegex.test('ÄÖÑÜ§çabcdefghijklmnopqrstuvwxyzäöñüà'));
+				assert(gsmCoder.GSM_TR.charRegex.test('\f^{}\\[~]|ĞİŞç€ğış'));
+			});
+
+			it('should return false for strings that can not be encoded using GSM 03.38 Turkish Shift Table charset', function() {
+				assert(!gsmCoder.GSM_TR.charRegex.test('`'));
+				assert(!gsmCoder.GSM_TR.charRegex.test('ąęłńśż'));
+				assert(!gsmCoder.GSM_TR.charRegex.test('ကြယ်တာရာ'));
+			});
+		});
+
+		describe('#encode', function() {
+			it('should properly encode the given string using GSM 03.38 Spanish Shift Table charset', function() {
+				for(var str in samples) {
+					assert.deepEqual(gsmCoder.encode(str, 0x01), new Buffer(samples[str]));
+				}
+			});
+		});
+
+		describe('#decode', function() {
+			it('should properly decode the given buffer using GSM 03.38 Spanish Shift Table charset', function() {
+				for(var str in samples) {
+					assert.deepEqual(gsmCoder.decode(samples[str], 0x01), str);
+				}
+			});
+		});
+	});
+
+	describe('GSM_ES', function() {
+		var samples = {
+			'@£$¥': [0, 1, 2, 3],
+			' 1a=': [0x20, 0x31, 0x61, 0x3D],
+			'~^€ú': [0x1B, 0x3D, 0x1B, 0x14, 0x1B, 0x65, 0x1B, 0x75]
+		};
+
+		describe('#match()', function() {
+			it('should return true for strings that can be encoded using GSM 03.38 Spanish Shift Table charset', function() {
+				assert(gsmCoder.GSM_ES.charRegex.test(''));
+				assert(gsmCoder.GSM_ES.charRegex.test('@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞ\x1BÆæßÉ !"#¤%&\''));
+				assert(gsmCoder.GSM_ES.charRegex.test('()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZ'));
+				assert(gsmCoder.GSM_ES.charRegex.test('ÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà'));
+				assert(gsmCoder.GSM_ES.charRegex.test('ç\f^{}\\[~]|ÁÍÓÚá€íóú'));
+			});
+
+			it('should return false for strings that can not be encoded using GSM 03.38 Spanish Shift Table charset', function() {
+				assert(!gsmCoder.GSM_ES.charRegex.test('`'));
+				assert(!gsmCoder.GSM_ES.charRegex.test('ąęłńśż'));
+				assert(!gsmCoder.GSM_ES.charRegex.test('ကြယ်တာရာ'));
+			});
+		});
+
+		describe('#encode', function() {
+			it('should properly encode the given string using GSM 03.38 Spanish Shift Table charset', function() {
+				for(var str in samples) {
+					assert.deepEqual(gsmCoder.encode(str, 0x02), new Buffer(samples[str]));
+				}
+			});
+		});
+
+		describe('#decode', function() {
+			it('should properly decode the given buffer using GSM 03.38 Spanish Shift Table charset', function() {
+				for(var str in samples) {
+					assert.deepEqual(gsmCoder.decode(samples[str], 0x02), str);
+				}
+			});
+		});
+	});
+
+	describe('GSM_PT', function() {
+		var samples = {
+			'@£$¥': [0, 1, 2, 3],
+			' 1a=Ã': [0x20, 0x31, 0x61, 0x3D, 0x5B],
+			'~^Σ': [0x1B, 0x3D, 0x1B, 0x14, 0x1B, 0x18]
+		};
+
+		describe('#match()', function() {
+			it('should return true for strings that can be encoded using GSM 03.38 Portuguese Shift Table charset', function() {
+				assert(gsmCoder.GSM_PT.charRegex.test(''));
+				assert(gsmCoder.GSM_PT.charRegex.test('@£$¥êéúíóç\nÔô\rÁáΔ_ªÇÀ∞^\\€Ó|\x1BÂâÊÉ !"#º%&\''));
+				assert(gsmCoder.GSM_PT.charRegex.test('()*+,-./0123456789:;<=>?ÍABCDEFGHIJKLMNOPQRSTUVWXYZ'));
+				assert(gsmCoder.GSM_PT.charRegex.test('ÃÕÚÜ§~abcdefghijklmnopqrstuvwxyzãõ`üà'));
+				assert(gsmCoder.GSM_PT.charRegex.test('êç\fÔô\rÁáΦΓ^ΩΠΨΣΘÊ{}\\[~]|ÀÍÓÚÃÕÂ€íóúãõâ'));
+			});
+
+			it('should return false for strings that can not be encoded using GSM 03.38 Portuguese Shift Table charset', function() {
+				assert(!gsmCoder.GSM_PT.charRegex.test('Æ'));
+				assert(!gsmCoder.GSM_PT.charRegex.test('ąęłńśż'));
+				assert(!gsmCoder.GSM_PT.charRegex.test('ਸਟਾਰ'));
+			});
+		});
+
+		describe('#encode', function() {
+			it('should properly encode the given string using GSM 03.38 Portuguese Shift Table charset', function() {
+				for(var str in samples) {
+					assert.deepEqual(gsmCoder.encode(str, 0x03), new Buffer(samples[str]));
+				}
+			});
+		});
+
+		describe('#decode', function() {
+			it('should properly decode the given buffer using GSM 03.38 Portuguese Shift Table charset', function() {
+				for(var str in samples) {
+					assert.deepEqual(gsmCoder.decode(samples[str], 0x03), str);
 				}
 			});
 		});

--- a/test/filters.js
+++ b/test/filters.js
@@ -29,13 +29,13 @@ describe('time', function() {
 	});
 });
 
-describe('message', function() {
+describe('message GSM', function() {
 	var pdu = {
 		data_coding: 0
 	};
 	var value = 'This is a Test';
-	var value2 = {message: 'This is a Test'};
-	var value3 = {message: new Buffer('This is a Test')};
+	var value2 = {message: value};
+	var value3 = {message: new Buffer(value)};
 	var encoded = new Buffer(value);
 	describe('#encode()', function() {
 		it('should encode a high-level formatted short message to a low-level buffer', function() {
@@ -45,8 +45,107 @@ describe('message', function() {
 		});
 	});
 	describe('#decode()', function() {
-		it('should convert a short message buffer to an object contaning message and optional udh', function() {
+		it('should convert a short message buffer to an object containing message and optional udh', function() {
 			assert.deepEqual(filters.message.decode.call(pdu, encoded), value2);
+		});
+	});
+});
+
+describe('message GSM_TR', function() {
+	var stream = [0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x54, 0x65, 0x1D, 0x74];
+
+	var encodePdu = {
+		data_coding: 0
+	};
+	var encodeValue = {
+		udh: new Buffer([0x03, 0x24, 0x01, 0x01]),
+		message: 'This is a Teşt'
+	};
+	var encoded = new Buffer([0x03, 0x24, 0x01, 0x01, ...stream]);
+	describe('#encode()', function() {
+		it('should encode a high-level formatted short message to a low-level buffer', function() {
+			assert.deepEqual(filters.message.encode.call(encodePdu, encodeValue), encoded);
+			process.exit();
+		});
+	});
+	var decodePdu = {
+		data_coding: 0,
+		esm_class: 0x40
+	};
+	var decodeValue = new Buffer([0x03, 0x24, 0x01, 0x01, ...stream]);
+	var decoded = {
+		udh: new Buffer([0x03, 0x24, 0x01, 0x01]),
+		message: encodeValue
+	};
+	describe('#decode()', function() {
+		it('should convert a short message buffer to an object containing message and optional udh', function() {
+			assert.deepEqual(filters.message.decode.call(decodePdu, decodeValue), decoded);
+		});
+	});
+});
+
+describe('message GSM_ES', function() {
+	var stream = [0x54, 0x68, 0x69, 0x73, 0x20, 0x1B, 0x69, 0x73, 0x20, 0x61, 0x20, 0x54, 0x05, 0x73, 0x74];
+
+	var encodePdu = {
+		data_coding: 0
+	};
+	var encodeValue = {
+		udh: new Buffer([0x03, 0x25, 0x01, 0x02]),
+		message: 'This ís a Tést'
+	};
+	var encoded = new Buffer([0x03, 0x25, 0x01, 0x02, ...stream]);
+	describe('#encode()', function() {
+		it('should encode a high-level formatted short message to a low-level buffer', function() {
+			assert.deepEqual(filters.message.encode.call(encodePdu, encodeValue), encoded);
+		});
+	});
+
+	var decodePdu = {
+		data_coding: 0,
+		esm_class: 0x40
+	};
+	var decodeValue = new Buffer([0x03, 0x25, 0x01, 0x02, ...stream]);
+	var decoded = {
+		udh: new Buffer([0x03, 0x25, 0x01, 0x02]),
+		message: encodeValue
+	};
+	describe('#decode()', function() {
+		it('should convert a short message buffer to an object containing message and optional udh', function() {
+			assert.deepEqual(filters.message.decode.call(decodePdu, decodeValue), decoded);
+		});
+	});
+});
+
+describe('message GSM_PT', function() {
+	var stream = [0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x1D, 0x20, 0x54, 0x1B, 0x18, 0x73, 0x74];
+
+	var encodePdu = {
+		data_coding: 0
+	};
+	var encodeValue = {
+		udh: new Buffer([0x03, 0x25, 0x01, 0x03]),
+		message: 'This is â TΣst'
+	};
+	var encoded = new Buffer([0x03, 0x25, 0x01, 0x03, ...stream]);
+	describe('#encode()', function() {
+		it('should encode a high-level formatted short message to a low-level buffer', function() {
+			assert.deepEqual(filters.message.encode.call(encodePdu, encodeValue), encoded);
+		});
+	});
+
+	var decodePdu = {
+		data_coding: 0,
+		esm_class: 0x40
+	};
+	var decodeValue = new Buffer([0x03, 0x24, 0x01, 0x03, ...stream]);
+	var decoded = {
+		udh: new Buffer([0x03, 0x24, 0x01, 0x03]),
+		message: encodeValue
+	};
+	describe('#decode()', function() {
+		it('should convert a short message buffer to an object containing message and optional udh', function() {
+			assert.deepEqual(filters.message.decode.call(decodePdu, decodeValue), decoded);
 		});
 	});
 });

--- a/test/filters.js
+++ b/test/filters.js
@@ -71,9 +71,13 @@ describe('message GSM_TR', function() {
 		data_coding: 0,
 		esm_class: 0x40
 	};
+	var decodeValue = {
+		udh: [udh.slice(1)],
+		message: 'This is a Teşt'
+	};
 	describe('#decode()', function() {
 		it('should convert a short message buffer to an object containing message and optional udh', function() {
-			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), value);
+			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), decodeValue);
 		});
 	});
 });
@@ -99,9 +103,13 @@ describe('message GSM_ES', function() {
 		data_coding: 0,
 		esm_class: 0x40
 	};
+	var decodeValue = {
+		udh: [udh.slice(1)],
+		message: 'This ís a Tést'
+	};
 	describe('#decode()', function() {
 		it('should convert a short message buffer to an object containing message and optional udh', function() {
-			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), value);
+			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), decodeValue);
 		});
 	});
 });
@@ -127,9 +135,13 @@ describe('message GSM_PT', function() {
 		data_coding: 0,
 		esm_class: 0x40
 	};
+	var decodeValue = {
+		udh: [udh.slice(1)],
+		message: 'This is â TΣst'
+	};
 	describe('#decode()', function() {
 		it('should convert a short message buffer to an object containing message and optional udh', function() {
-			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), value);
+			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), decodeValue);
 		});
 	});
 });

--- a/test/filters.js
+++ b/test/filters.js
@@ -52,52 +52,46 @@ describe('message GSM', function() {
 });
 
 describe('message GSM_TR', function() {
-	var stream = [0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x54, 0x65, 0x1D, 0x74];
+	var udh = new Buffer([0x03, 0x24, 0x01, 0x01]);
+	var value = {
+		udh: udh,
+		message: 'This is a Teşt'
+	};
+	var encoded = Buffer.concat([udh, new Buffer([0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x54, 0x65, 0x1D, 0x74])]);
 
 	var encodePdu = {
 		data_coding: 0
 	};
-	var encodeValue = {
-		udh: new Buffer([0x03, 0x24, 0x01, 0x01]),
-		message: 'This is a Teşt'
-	};
-	var encoded = new Buffer([0x03, 0x24, 0x01, 0x01, ...stream]);
 	describe('#encode()', function() {
 		it('should encode a high-level formatted short message to a low-level buffer', function() {
-			assert.deepEqual(filters.message.encode.call(encodePdu, encodeValue), encoded);
-			process.exit();
+			assert.deepEqual(filters.message.encode.call(encodePdu, value), encoded);
 		});
 	});
 	var decodePdu = {
 		data_coding: 0,
 		esm_class: 0x40
 	};
-	var decodeValue = new Buffer([0x03, 0x24, 0x01, 0x01, ...stream]);
-	var decoded = {
-		udh: new Buffer([0x03, 0x24, 0x01, 0x01]),
-		message: encodeValue
-	};
 	describe('#decode()', function() {
 		it('should convert a short message buffer to an object containing message and optional udh', function() {
-			assert.deepEqual(filters.message.decode.call(decodePdu, decodeValue), decoded);
+			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), value);
 		});
 	});
 });
 
 describe('message GSM_ES', function() {
-	var stream = [0x54, 0x68, 0x69, 0x73, 0x20, 0x1B, 0x69, 0x73, 0x20, 0x61, 0x20, 0x54, 0x05, 0x73, 0x74];
+	var udh = new Buffer([0x03, 0x25, 0x01, 0x02]);
+	var value = {
+		udh: udh,
+		message: 'This ís a Tést'
+	};
+	var encoded = Buffer.concat([udh, new Buffer([0x54, 0x68, 0x69, 0x73, 0x20, 0x1B, 0x69, 0x73, 0x20, 0x61, 0x20, 0x54, 0x05, 0x73, 0x74])]);
 
 	var encodePdu = {
 		data_coding: 0
 	};
-	var encodeValue = {
-		udh: new Buffer([0x03, 0x25, 0x01, 0x02]),
-		message: 'This ís a Tést'
-	};
-	var encoded = new Buffer([0x03, 0x25, 0x01, 0x02, ...stream]);
 	describe('#encode()', function() {
 		it('should encode a high-level formatted short message to a low-level buffer', function() {
-			assert.deepEqual(filters.message.encode.call(encodePdu, encodeValue), encoded);
+			assert.deepEqual(filters.message.encode.call(encodePdu, value), encoded);
 		});
 	});
 
@@ -105,32 +99,27 @@ describe('message GSM_ES', function() {
 		data_coding: 0,
 		esm_class: 0x40
 	};
-	var decodeValue = new Buffer([0x03, 0x25, 0x01, 0x02, ...stream]);
-	var decoded = {
-		udh: new Buffer([0x03, 0x25, 0x01, 0x02]),
-		message: encodeValue
-	};
 	describe('#decode()', function() {
 		it('should convert a short message buffer to an object containing message and optional udh', function() {
-			assert.deepEqual(filters.message.decode.call(decodePdu, decodeValue), decoded);
+			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), value);
 		});
 	});
 });
 
 describe('message GSM_PT', function() {
-	var stream = [0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x1D, 0x20, 0x54, 0x1B, 0x18, 0x73, 0x74];
+	var udh = new Buffer([0x03, 0x25, 0x01, 0x03]);
+	var value = {
+		udh: udh,
+		message: 'This is â TΣst'
+	};
+	var encoded = Buffer.concat([udh, new Buffer([0x54, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x1D, 0x20, 0x54, 0x1B, 0x18, 0x73, 0x74])]);
 
 	var encodePdu = {
 		data_coding: 0
 	};
-	var encodeValue = {
-		udh: new Buffer([0x03, 0x25, 0x01, 0x03]),
-		message: 'This is â TΣst'
-	};
-	var encoded = new Buffer([0x03, 0x25, 0x01, 0x03, ...stream]);
 	describe('#encode()', function() {
 		it('should encode a high-level formatted short message to a low-level buffer', function() {
-			assert.deepEqual(filters.message.encode.call(encodePdu, encodeValue), encoded);
+			assert.deepEqual(filters.message.encode.call(encodePdu, value), encoded);
 		});
 	});
 
@@ -138,14 +127,9 @@ describe('message GSM_PT', function() {
 		data_coding: 0,
 		esm_class: 0x40
 	};
-	var decodeValue = new Buffer([0x03, 0x24, 0x01, 0x03, ...stream]);
-	var decoded = {
-		udh: new Buffer([0x03, 0x24, 0x01, 0x03]),
-		message: encodeValue
-	};
 	describe('#decode()', function() {
 		it('should convert a short message buffer to an object containing message and optional udh', function() {
-			assert.deepEqual(filters.message.decode.call(decodePdu, decodeValue), decoded);
+			assert.deepEqual(filters.message.decode.call(decodePdu, encoded), value);
 		});
 	});
 });

--- a/test/pdu.js
+++ b/test/pdu.js
@@ -99,6 +99,7 @@ describe('PDU', function() {
 				dest_addr_ton: 1,
 				dest_addr_npi: 1,
 				destination_addr: '46709771337',
+				esm_class: 64,
 				short_message: {
 					udh: new Buffer([0x03, 0x24, 0x01, 0x03]),
 					message: 'tãst'

--- a/test/pdu.js
+++ b/test/pdu.js
@@ -6,11 +6,11 @@ describe('PDU', function() {
 	var buffer, expected;
 
 	beforeEach(function() {
-		buffer = new Buffer('0000003b000000040000000000000002' +
+		buffer = new Buffer('0000003f000000040000000000000002' +
 			'00010034363730313133333131310001013436373039373' +
-			'731333337000000000000000001000474657374', 'hex');
+			'731333337004000000000000001000803240103747B7374', 'hex');
 		expected = {
-			command_length: 59,
+			command_length: 63,
 			command_id: 4,
 			command_status: 0,
 			sequence_number: 2,
@@ -22,7 +22,7 @@ describe('PDU', function() {
 			dest_addr_ton: 1,
 			dest_addr_npi: 1,
 			destination_addr: '46709771337',
-			esm_class: 0,
+			esm_class: 64,
 			protocol_id: 0,
 			priority_flag: 0,
 			schedule_delivery_time: '',
@@ -31,7 +31,10 @@ describe('PDU', function() {
 			replace_if_present_flag: 0,
 			data_coding: 1,
 			sm_default_msg_id: 0,
-			short_message: { message: 'test' }
+			short_message: {
+				udh: new Buffer([0x03, 0x24, 0x01, 0x03]),
+				message: 'tãst'
+			}
 		};
 	});
 
@@ -44,9 +47,11 @@ describe('PDU', function() {
 
 		it('should extract tlv parameters if available', function() {
 			var b = Buffer.concat([buffer, Buffer('0424000474657374', 'hex')]);
-			b[3] = 67;
-			expected.command_length = 67;
-			expected.message_payload = { message: 'test' };
+			b[3] = 71;
+			expected.command_length = 71;
+			expected.message_payload = {
+				message: 'test'
+			};
 			var pdu = new PDU(b);
 			assert.deepEqual(pdu, expected);
 		});
@@ -94,7 +99,10 @@ describe('PDU', function() {
 				dest_addr_ton: 1,
 				dest_addr_npi: 1,
 				destination_addr: '46709771337',
-				short_message: 'test'
+				short_message: {
+					udh: new Buffer([0x03, 0x24, 0x01, 0x03]),
+					message: 'tãst'
+				}
 			};
 			var pdu = new PDU('submit_sm', submit_sm);
 			assert.deepEqual(pdu.toBuffer(), buffer);

--- a/test/pdu.js
+++ b/test/pdu.js
@@ -32,7 +32,7 @@ describe('PDU', function() {
 			data_coding: 1,
 			sm_default_msg_id: 0,
 			short_message: {
-				udh: new Buffer([0x03, 0x24, 0x01, 0x03]),
+				udh: [new Buffer([0x24, 0x01, 0x03])],
 				message: 'tãst'
 			}
 		};
@@ -49,9 +49,7 @@ describe('PDU', function() {
 			var b = Buffer.concat([buffer, Buffer('0424000474657374', 'hex')]);
 			b[3] = 71;
 			expected.command_length = 71;
-			expected.message_payload = {
-				message: 'test'
-			};
+			expected.message_payload = { message: 'test' };
 			var pdu = new PDU(b);
 			assert.deepEqual(pdu, expected);
 		});
@@ -109,7 +107,6 @@ describe('PDU', function() {
 			assert.deepEqual(pdu.toBuffer(), buffer);
 
 			submit_sm.data_coding = 0;
-			buffer[52] = 0;
 			var pdu = new PDU('submit_sm', submit_sm);
 			assert.deepEqual(pdu.toBuffer(), buffer);
 		});


### PR DESCRIPTION
This PR adds support to GSM language shift tables as presented in issue #91 

Added support for receiving and sending GSM messages encoded with shift tables, currently Turkish, Spanish and Portuguese but can be easily extended for other languages

Information about shift tables can be found here: https://en.wikipedia.org/wiki/GSM_03.38

Mind that for this task to be achieved UDH must be parsed and understood in order to retrieve selected shift table. udh field is returned now as an array of Buffer **without** total udh length

having this UDH `Buffer([0x08, 0x24, 0x01, 0x03, 0x00, 0x03, 0x08, 0x02, 0x01])`, udh field will store:
```
[
    Buffer([0x24, 0x01, 0x03]), // Language Shift Table (portuguese)
    Buffer([0x00, 0x03, 0x08, 0x02, 0x01]) // 8bit Concatenated short message (part 1 of 2)
]
```