### PR TITLE
Bump PDU max length to 73728

### DIFF
--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -201,6 +201,6 @@ PDU.prototype.toBuffer = function() {
 	return buffer;
 };
 
-PDU.maxLength = 16384;
+PDU.maxLength = /* message_payload max */ 65536 + /* some arbitrary value */ 8192;
 
 exports.PDU = PDU;


### PR DESCRIPTION
message_payload alone is specified to be able to hold up to 64K octets, so the existing 16384 seems too low.