### PR TITLE
Fixed infinite loop

### DIFF
--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -40,7 +40,7 @@ function PDU(command, options) {
 	}
 }
 
-PDU.fromStream = function(stream) {
+PDU.commandLength = function(stream) {
 	var buffer = stream.read(4);
 	if (!buffer) {
 		return false;
@@ -50,12 +50,19 @@ PDU.fromStream = function(stream) {
 		throw Error('PDU length was too large (' + command_length +
 			', maximum is ' + PDU.maxLength + ').');
 	}
-	stream.unshift(buffer);
-	buffer = stream.read(command_length);
+	return command_length;
+};
+
+PDU.fromStream = function(stream, command_length) {
+	var buffer = stream.read(command_length - 4);
 	if (!buffer) {
 		return false;
 	}
-	return new PDU(buffer);
+	let buf = Buffer.alloc(4);
+	buf.writeUInt32BE(command_length);
+	var pduBuffer = Buffer.concat([buf, buffer]);
+
+	return new PDU(pduBuffer);
 };
 
 PDU.fromBuffer = function(buffer) {

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -58,9 +58,9 @@ PDU.fromStream = function(stream, command_length) {
 	if (!buffer) {
 		return false;
 	}
-	let buf = Buffer.alloc(4);
-	buf.writeUInt32BE(command_length);
-	var pduBuffer = Buffer.concat([buf, buffer]);
+	var commandLengthBuffer = Buffer.alloc(4);
+	commandLengthBuffer.writeUInt32BE(command_length);
+	var pduBuffer = Buffer.concat([commandLengthBuffer, buffer]);
 
 	return new PDU(pduBuffer);
 };

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -59,7 +59,7 @@ PDU.fromStream = function(stream, command_length) {
 		return false;
 	}
 	var commandLengthBuffer = Buffer.alloc(4);
-	commandLengthBuffer.writeUInt32BE(command_length);
+	commandLengthBuffer.writeUInt32BE(command_length, 0);
 	var pduBuffer = Buffer.concat([commandLengthBuffer, buffer]);
 
 	return new PDU(pduBuffer);

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -16,6 +16,7 @@ function Session(options) {
 	this._busy = false;
 	this._callbacks = [];
 	this._interval = 0;
+	this._command_length = null;
 	if (options.socket) {
 		this.socket = options.socket;
 	} else {
@@ -70,13 +71,20 @@ Session.prototype._extractPDUs = function() {
 	var pdu;
 	while (!this.paused) {
 		try {
-			if (!(pdu = PDU.fromStream(this.socket))) {
+			if(!this._command_length) {
+				this._command_length = PDU.commandLength(this.socket);
+				if(!this._command_length) {
+					break;
+				}
+			}
+			if (!(pdu = PDU.fromStream(this.socket, this._command_length))) {
 				break;
 			}
 		} catch (e) {
 			this.emit('error', e);
 			return;
 		}
+		this._command_length = null;
 		this.emit('pdu', pdu);
 		this.emit(pdu.command, pdu);
 		if (pdu.isResponse() && this._callbacks[pdu.sequence_number]) {

--- a/test/pdu.js
+++ b/test/pdu.js
@@ -76,7 +76,8 @@ describe('PDU', function() {
 			var readable = new stream.Readable();
 			readable._read = function() {} ;
 			readable.push(buffer);
-			var pdu = PDU.fromStream(readable);
+			var commandLength = PDU.commandLength(readable);
+			var pdu = PDU.fromStream(readable, commandLength);
 			assert.deepEqual(pdu, expected);
 		});
 	});


### PR DESCRIPTION
Here is the fix for the issue described here https://github.com/farhadi/node-smpp/issues/152
It removes the usage of [ stream.unshift ](https://nodejs.org/api/stream.html#stream_readable_unshift_chunk_encoding) which is the root cause of the infinite loop. 

P.S. I have created this fix a few months ago and it worked fine, but I'm not using node-smpp actively anymore so please test it carefully before merging with master. 