### PR TITLE
prevent collision on message_state TLV for query_sm_resp PDUs

### DIFF
--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -35,12 +35,8 @@ function PDU(command, options) {
 			this[key] = params[key].type.default;
 		}
 	}
-	for (var key in options) {
-		if (key in tlvs
-			&& (key !== 'message_state'
-				|| ['query_sm_resp', 'query_broadcast_sm_resp'].indexOf(this.command) === -1)) {
-			this[key] = options[key];
-		}
+	for (var key in options) if (key in tlvs && !(key in params)) {
+		this[key] = options[key];
 	}
 }
 
@@ -198,20 +194,16 @@ PDU.prototype.toBuffer = function() {
 		params[key].type.write(this[key], buffer, offset);
 		offset += params[key].type.size(this[key]);
 	}
-	for (var key in this) {
-		if (tlvs[key]
-			&& (key !== 'message_state'
-				|| ['query_sm_resp', 'query_broadcast_sm_resp'].indexOf(this.command) === -1)) {
-			var values = tlvs[key].multiple ? this[key] : [this[key]];
-			values.forEach(function(value) {
-				buffer.writeUInt16BE(tlvs[key].id, offset);
-				var length = tlvs[key].type.size(value);
-				buffer.writeUInt16BE(length, offset + 2);
-				offset += 4;
-				tlvs[key].type.write(value, buffer, offset);
-				offset += length;
-			});
-		}
+	for (var key in this) if (tlvs[key] && !(key in params)) {
+		var values = tlvs[key].multiple ? this[key] : [this[key]];
+		values.forEach(function(value) {
+			buffer.writeUInt16BE(tlvs[key].id, offset);
+			var length = tlvs[key].type.size(value);
+			buffer.writeUInt16BE(length, offset + 2);
+			offset += 4;
+			tlvs[key].type.write(value, buffer, offset);
+			offset += length;
+		});
 	}
 	return buffer;
 };

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -35,8 +35,10 @@ function PDU(command, options) {
 			this[key] = params[key].type.default;
 		}
 	}
-	for (var key in options) if (key in tlvs) {
-		this[key] = options[key];
+	for (var key in options) {
+		if (key in tlvs && (key !== 'message_state' || this.command !== 'query_sm_resp')) {
+			this[key] = options[key];
+		}
 	}
 }
 
@@ -93,7 +95,7 @@ PDU.prototype.fromBuffer = function(buffer) {
 		this[key] = buffer.readUInt32BE(i * 4);
 	}.bind(this));
 	//Since each pduHeaderParam is 4 bytes/octets, the offset is equal to the total length of the
-	//pduHeadParams*4, its better to use that basis for maintainance.
+	//pduHeadParams*4, its better to use that basis for maintenance.
 	var params, offset = pduHeadParams.length * 4;
 	if (this.command_length > PDU.maxLength) {
 		throw Error('PDU length was too large (' + this.command_length +
@@ -194,16 +196,19 @@ PDU.prototype.toBuffer = function() {
 		params[key].type.write(this[key], buffer, offset);
 		offset += params[key].type.size(this[key]);
 	}
-	for (var key in this) if (tlvs[key]) {
-		var values = tlvs[key].multiple ? this[key] : [this[key]];
-		values.forEach(function(value) {
-			buffer.writeUInt16BE(tlvs[key].id, offset);
-			var length = tlvs[key].type.size(value);
-			buffer.writeUInt16BE(length, offset + 2);
-			offset += 4;
-			tlvs[key].type.write(value, buffer, offset);
-			offset += length;
-		});
+	for (var key in this) {
+		if (tlvs[key] && (key !== 'message_state' || this.command !== 'query_sm_resp')) {
+			console.log(key);
+			var values = tlvs[key].multiple ? this[key] : [this[key]];
+			values.forEach(function(value) {
+				buffer.writeUInt16BE(tlvs[key].id, offset);
+				var length = tlvs[key].type.size(value);
+				buffer.writeUInt16BE(length, offset + 2);
+				offset += 4;
+				tlvs[key].type.write(value, buffer, offset);
+				offset += length;
+			});
+		}
 	}
 	return buffer;
 };

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -202,7 +202,6 @@ PDU.prototype.toBuffer = function() {
 		if (tlvs[key]
 			&& (key !== 'message_state'
 				|| ['query_sm_resp', 'query_broadcast_sm_resp'].indexOf(this.command) === -1)) {
-			console.log(key);
 			var values = tlvs[key].multiple ? this[key] : [this[key]];
 			values.forEach(function(value) {
 				buffer.writeUInt16BE(tlvs[key].id, offset);

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -36,7 +36,9 @@ function PDU(command, options) {
 		}
 	}
 	for (var key in options) {
-		if (key in tlvs && (key !== 'message_state' || this.command !== 'query_sm_resp')) {
+		if (key in tlvs
+			&& (key !== 'message_state'
+				|| ['query_sm_resp', 'query_broadcast_sm_resp'].indexOf(this.command) === -1)) {
 			this[key] = options[key];
 		}
 	}
@@ -197,7 +199,9 @@ PDU.prototype.toBuffer = function() {
 		offset += params[key].type.size(this[key]);
 	}
 	for (var key in this) {
-		if (tlvs[key] && (key !== 'message_state' || this.command !== 'query_sm_resp')) {
+		if (tlvs[key]
+			&& (key !== 'message_state'
+				|| ['query_sm_resp', 'query_broadcast_sm_resp'].indexOf(this.command) === -1)) {
 			console.log(key);
 			var values = tlvs[key].multiple ? this[key] : [this[key]];
 			values.forEach(function(value) {

--- a/test/pdu.js
+++ b/test/pdu.js
@@ -92,6 +92,8 @@ describe('PDU', function() {
 
 	describe('#toBuffer()', function() {
 		it('should create a buffer from a PDU object', function() {
+			var b = Buffer.concat([buffer, Buffer.from('0427000106', 'hex')]);
+			b[3] = 68;
 			var submit_sm = {
 				sequence_number: 2,
 				source_addr_ton: 1,
@@ -103,14 +105,25 @@ describe('PDU', function() {
 				short_message: {
 					udh: Buffer.from([0x03, 0x24, 0x01, 0x03]),
 					message: 'tãst'
-				}
+				},
+				message_state: 6
 			};
 			var pdu = new PDU('submit_sm', submit_sm);
-			assert.deepEqual(pdu.toBuffer(), buffer);
+			assert.deepEqual(pdu.toBuffer(), b);
 
 			submit_sm.data_coding = 0;
 			var pdu = new PDU('submit_sm', submit_sm);
-			assert.deepEqual(pdu.toBuffer(), buffer);
+			assert.deepEqual(pdu.toBuffer(), b);
+		});
+
+		it('should create a buffer from a query_sm_resp PDU object', function() {
+			var b = Buffer.from('0000001480000003000000000000000200000200', 'hex');
+			var query_sm_resp = {
+				sequence_number: 2,
+				message_state: 2
+			};
+			var pdu = new PDU('query_sm_resp', query_sm_resp);
+			assert.deepEqual(pdu.toBuffer(), b);
 		});
 	});
 


### PR DESCRIPTION
Covers #158 

message_state is a mandatory parameter for query_sm_resp and query_broadcast_sm_resp PDU, and at the same time it is an optional parameter for other PDUs, this causes a collision on such PDUs

As this is the only optional parameter that suffers from this duplicity among optional and mandatory parameters (SMPP v5), this PR simply solves the issue by skipping the TLV for query_sm_resp and query_broadcast_sm_resp PDUs