### PR TITLE
move _callbacks to an object to avoid empty slots

### DIFF
--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -14,7 +14,7 @@ function Session(options) {
 	this.sequence = 0;
 	this.paused = false;
 	this._busy = false;
-	this._callbacks = [];
+	this._callbacks = {};
 	this._interval = 0;
 	this._command_length = null;
 	if (options.socket) {
@@ -59,7 +59,7 @@ Session.prototype.connect = function() {
 	this.sequence = 0;
 	this.paused = false;
 	this._busy = false;
-	this._callbacks = [];
+	this._callbacks = {};
 	this.socket.connect(this.options);
 };
 


### PR DESCRIPTION
I noticed by logging sessions that _callbacks kept growing to [null,null,null,null...] for every smpp request
After investigation, I found the issue to be that the use of an array for _callbacks. 
This pr changes it to an object to solve the issue.

Fixes #170  