### PR TITLE
Bugfix of type casting in pdu.js

### DIFF
--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -28,7 +28,7 @@ function PDU(command, options) {
 	var params = commands[command].params || {};
 	for (var key in params) {
 		if (key in options) {
-			this[key] = options[key];
+			this[key] = (params[key].type == defs.types.cstring || params[key].type == defs.types.string) && typeof options[key] != 'string' ? String(options[key]) : options[key];
 		} else if ('default' in params[key]) {
 			this[key] = params[key].default;
 		} else {


### PR DESCRIPTION
Casting the type of user's PDU parameter to a string if it should be cstring or string. This prevents from crash when a numeric or other type is assigned to a string parameter. For example, when the type of source_addr is a number.