### PR TITLE
Client & Server debug feature implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,24 +34,26 @@ Usage
 var smpp = require('smpp');
 var session = smpp.connect({
 	url: 'smpp://example.com:2775',
-	auto_enquire_link_period: 10000
-});
-session.bind_transceiver({
-	system_id: 'YOUR_SYSTEM_ID',
-	password: 'YOUR_PASSWORD'
-}, function(pdu) {
-	if (pdu.command_status == 0) {
-		// Successfully bound
-		session.submit_sm({
-			destination_addr: 'DESTINATION NUMBER',
-			short_message: 'Hello!'
-		}, function(pdu) {
-			if (pdu.command_status == 0) {
-				// Message successfully sent
-				console.log(pdu.message_id);
-			}
-		});
-	}
+	auto_enquire_link_period: 10000,
+	debug: true
+}, function() {
+	session.bind_transceiver({
+		system_id: 'YOUR_SYSTEM_ID',
+		password: 'YOUR_PASSWORD'
+	}, function(pdu) {
+		if (pdu.command_status === 0) {
+			// Successfully bound
+			session.submit_sm({
+				destination_addr: 'DESTINATION NUMBER',
+				short_message: 'Hello!'
+			}, function(pdu) {
+				if (pdu.command_status === 0) {
+					// Message successfully sent
+					console.log(pdu.message_id);
+				}
+			});
+		}
+	});
 });
 ```
 
@@ -59,7 +61,9 @@ session.bind_transceiver({
 
 ``` javascript
 var smpp = require('smpp');
-var server = smpp.createServer(function(session) {
+var server = smpp.createServer({
+	debug: true
+}, function(session) {
 	session.on('bind_transceiver', function(pdu) {
 		// we pause the session to prevent further incoming pdu events,
 		// untill we authorize the session with some async operation.
@@ -78,6 +82,16 @@ var server = smpp.createServer(function(session) {
 	});
 });
 server.listen(2775);
+```
+
+### Debug
+To enable a simple debug of ingoing/outgoing messages pass `debug: true` as server/client option. Debug is disabled by default.
+
+Alternatively, you can listen for the `debug` even and write your own implementation:
+``` javascript
+session.on('debug', function(type, msg, payload) {
+	console.log({type: type, msg: msg, payload: payload});
+});
 ```
 
 Encodings

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -6,7 +6,7 @@ var net = require('net'),
 	PDU = require('./pdu').PDU,
 	EventEmitter = require('events').EventEmitter;
 
-function Session(mode, options) {
+function Session(options) {
 	EventEmitter.call(this);
 	this.options = options || {};
 	var self = this;
@@ -19,14 +19,16 @@ function Session(mode, options) {
 	this._callbacks = {};
 	this._interval = 0;
 	this._command_length = null;
-	this._mode = mode;
+	this._mode = null;
 	this._id = Math.floor(Math.random() * (999999 - 100000)) + 100000; // random session id
 	this._prevBytesRead = 0;
 	if (options.socket) {
 		// server mode
+		this._mode = "server";
 		this.socket = options.socket;
 	} else {
 		// client mode
+		this._mode = "client";
 		if (options.tls) {
 			transport = tls;
 		}
@@ -242,7 +244,7 @@ function Server(options, listener) {
 	this.options = options;
 
 	transport.Server.call(this, options, function(socket) {
-		var session = new Session("server", {socket: socket, debug: self.options.debug});
+		var session = new Session({socket: socket, debug: self.options.debug});
 		session.debug("client.connected", "client has connected");
 		session.server = self;
 		self.sessions.push(session);
@@ -315,7 +317,7 @@ exports.connect = exports.createSession = function(url, listener) {
 	options.port = options.port || (options.tls ? 3550 : 2775);
 	options.debug = options.debug || false;
 
-	var session = new Session("client", options);
+	var session = new Session(options);
 	if (listener) {
 		session.on(options.tls ? 'secureConnect' : 'connect', listener);
 	}

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -6,38 +6,63 @@ var net = require('net'),
 	PDU = require('./pdu').PDU,
 	EventEmitter = require('events').EventEmitter;
 
-function Session(options) {
+function Session(mode, options) {
 	EventEmitter.call(this);
 	this.options = options || {};
 	var self = this;
 	var transport = net;
+	this._extractPDUs = this._extractPDUs.bind(self);
 	this.sequence = 0;
 	this.paused = false;
+	this.remoteAddress = null;
 	this._busy = false;
 	this._callbacks = {};
 	this._interval = 0;
 	this._command_length = null;
+	this._mode = mode;
+	this._id = Math.floor(Math.random() * (999999 - 100000)) + 100000; // random session id
+	this._prevBytesRead = 0;
 	if (options.socket) {
+		// server mode
 		this.socket = options.socket;
 	} else {
+		// client mode
 		if (options.tls) {
 			transport = tls;
 		}
 		this.socket = transport.connect(this.options);
-		this.socket.on('connect', function() {
-			self.emit('connect');
+		this.socket.on('connect', (function() {
+			self.remoteAddress = self.socket.remoteAddress;
+			self.debug("server.connected", "connected to server", {secure: options.tls});
+			self.emit('connect'); // @todo should emmit the session, but it would break BC
 			if(self.options.auto_enquire_link_period) {
 				self._interval = setInterval(function() {
 					self.enquire_link();
 				}, self.options.auto_enquire_link_period);
 			}
-		});
-		this.socket.on('secureConnect', function() {
-			self.emit('secureConnect');
-		});
+		}).bind(this));
+		this.socket.on('secureConnect', (function() {
+			self.emit('secureConnect'); // @todo should emmit the session, but it would break BC
+		}).bind(this));
 	}
-	this.socket.on('readable', this._extractPDUs.bind(this));
+	this.remoteAddress = this.socket.remoteAddress;
+	this.socket.on('open', function() {
+		self.debug("socket.open");
+	});
+	this.socket.on('readable', function() {
+		if ( (self.socket.bytesRead - self._prevBytesRead) > 0 ) {
+			// on disconnections the readable event receives 0 bytes, we do not want to debug that
+			self.debug("socket.data.in", null, {bytes: self.socket.bytesRead - self._prevBytesRead});
+			self._prevBytesRead = self.socket.bytesRead;
+		}
+		self._extractPDUs();
+	});
 	this.socket.on('close', function() {
+		if (self._mode === "server") {
+			self.debug("client.disconnected", "client has disconnected");
+		} else {
+			self.debug("server.disconnected", "disconnected from server");
+		}
 		self.emit('close');
 		if(self._interval) {
 			clearInterval(self._interval);
@@ -45,7 +70,8 @@ function Session(options) {
 		}
 	});
 	this.socket.on('error', function(e) {
-		self.emit('error', e);
+		self.debug("socket.error", e.message, e);
+		self.emit('error', e); // Emitted errors will kill the program if they're not captured.
 		if(self._interval) {
 			clearInterval(self._interval);
 			self._interval = 0;
@@ -54,6 +80,34 @@ function Session(options) {
 }
 
 util.inherits(Session, EventEmitter);
+
+Session.prototype.debug = function(type, msg, payload) {
+	if (type === undefined) type = null;
+	if (msg === undefined) msg = null;
+	if (this.options.debug) {
+		var coloredTypes = {
+			"reset": "\x1b[0m",
+			"dim": "\x1b[2m",
+			"client.connected": "\x1b[1m\x1b[34m",
+			"client.disconnected": "\x1b[1m\x1b[31m",
+			"server.connected": "\x1b[1m\x1b[34m",
+			"server.disconnected": "\x1b[1m\x1b[31m",
+			"pdu.command.in": "\x1b[36m",
+			"pdu.command.out": "\x1b[32m",
+			"socket.error": "\x1b[41m\x1b[30m"
+		}
+		var now = new Date();
+		var logBuffer = now.toISOString() +
+			" - " + (this._mode === "server" ? "srv" : "cli") +
+			" - " + this._id +
+			" - " + (coloredTypes.hasOwnProperty(type) ? coloredTypes[type] + type + coloredTypes.reset : type) +
+			" - " + (msg !== null ? msg : "" ) +
+			" - " + coloredTypes.dim + (payload !== undefined ? JSON.stringify(payload) : "") + coloredTypes.reset;
+		if (this.remoteAddress) logBuffer += " - [" + this.remoteAddress + "]"
+		console.log( logBuffer );
+	}
+	this.emit('debug', type, msg, payload);
+}
 
 Session.prototype.connect = function() {
 	this.sequence = 0;
@@ -80,6 +134,7 @@ Session.prototype._extractPDUs = function() {
 			if (!(pdu = PDU.fromStream(this.socket, this._command_length))) {
 				break;
 			}
+			this.debug("pdu.command.in", pdu.command, pdu);
 		} catch (e) {
 			this.emit('error', e);
 			return;
@@ -116,12 +171,15 @@ Session.prototype.send = function(pdu, responseCallback, sendCallback) {
 	} else if (responseCallback && !sendCallback) {
 		sendCallback = responseCallback;
 	}
-	this.socket.write(pdu.toBuffer(), function() {
+	this.debug("pdu.command.out", pdu.command, pdu);
+	var buffer = pdu.toBuffer();
+	this.socket.write(buffer, (function() {
+		this.debug("socket.data.out", null, {bytes: buffer.length});
 		this.emit('send', pdu);
 		if (sendCallback) {
 			sendCallback(pdu);
 		}
-	}.bind(this));
+	}).bind(this));
 	return true;
 };
 
@@ -181,9 +239,11 @@ function Server(options, listener) {
 
 	this.tls = options.key && options.cert;
 	var transport = this.tls ? tls : net;
+	this.options = options;
 
 	transport.Server.call(this, options, function(socket) {
-		var session = new Session({socket: socket});
+		var session = new Session("server", {socket: socket, debug: self.options.debug});
+		session.debug("client.connected", "client has connected");
 		session.server = self;
 		self.sessions.push(session);
 		socket.on('close', function() {
@@ -240,7 +300,7 @@ exports.connect = exports.createSession = function(url, listener) {
 	} else if (typeof url == 'string') {
 		options = parse(url);
 		options.host = options.slashes ? options.hostname : url;
-		options.tls = options.protocol == 'ssmpp:';
+		options.tls = options.protocol === 'ssmpp:';
 	} else if (typeof url == 'function') {
 		listener = url;
 	} else {
@@ -249,12 +309,13 @@ exports.connect = exports.createSession = function(url, listener) {
 			url = parse(options.url);
 			options.host = url.hostname;
 			options.port = url.port;
-			options.tls = url.protocol == 'ssmpp:';
+			options.tls = url.protocol === 'ssmpp:';
 		}
 	}
 	options.port = options.port || (options.tls ? 3550 : 2775);
+	options.debug = options.debug || false;
 
-	var session = new Session(options);
+	var session = new Session("client", options);
 	if (listener) {
 		session.on(options.tls ? 'secureConnect' : 'connect', listener);
 	}

--- a/test/smpp.js
+++ b/test/smpp.js
@@ -30,22 +30,41 @@ describe('Server', function() {
 			var newPort = server.address().port;
 			assert.ok(newPort > 0, 'Invalid second random port');
 			assert.notEqual(newPort, port, 'Both random ports are equal!');
-		})
+		});
 	});
+
 });
 
 describe('Session', function() {
-	var server, port, secure = {};
+	var server, port, secure = {}, autoresponder = {};
+
 	var sessionHandler = function(session) {
-		session.on('pdu', function(pdu) {
+		session.on('enquire_link', function(pdu) {
 			session.send(pdu.response());
+		});
+		session.on('submit_sm', function(pdu) {
+			var response = pdu.response();
+			response.message_id = "123456789 sent to " + pdu.destination_addr; // Injected to verify the data received by the server
+			session.send(response);
+		});
+	};
+
+	var sessionHandlerAutoresponder = function(session) {
+		session.on('pdu', function(pdu) {
+			session.send(pdu.response()); // Always reply
 		});
 	};
 
 	before(function(done) {
-		server = smpp.createServer(sessionHandler);
+		server = smpp.createServer({}, sessionHandler);
 		server.listen(0, done);
 		port = server.address().port;
+	});
+
+	before(function(done) {
+		autoresponder.server = smpp.createServer({}, sessionHandlerAutoresponder);
+		autoresponder.server.listen(0, done);
+		autoresponder.port = autoresponder.server.address().port;
 	});
 
 	before(function(done) {
@@ -65,6 +84,13 @@ describe('Session', function() {
 	});
 
 	after(function(done) {
+		autoresponder.server.sessions.forEach(function(session) {
+			session.close();
+		});
+		autoresponder.server.close(done);
+	});
+
+	after(function(done) {
 		secure.server.sessions.forEach(function(session) {
 			session.close();
 		});
@@ -75,11 +101,11 @@ describe('Session', function() {
 		it('should use 2775 or 3550 as default port', function() {
 			var session = smpp.connect();
 			assert.equal(session.options.port, 2775);
-			var session = smpp.connect({tls: true});
+			session = smpp.connect({tls: true});
 			assert.equal(session.options.port, 3550);
-			var session = smpp.connect('smpp://localhost');
+			session = smpp.connect('smpp://localhost');
 			assert.equal(session.options.port, 2775);
-			var session = smpp.connect('ssmpp://localhost');
+			session = smpp.connect('ssmpp://localhost');
 			assert.equal(session.options.port, 3550);
 		});
 
@@ -87,7 +113,7 @@ describe('Session', function() {
 			var session = smpp.connect('127.0.0.1');
 			assert.equal(session.options.port, 2775);
 			assert.equal(session.options.host, '127.0.0.1');
-			var session = smpp.connect('127.0.0.1', 1234);
+			session = smpp.connect('127.0.0.1', 1234);
 			assert.equal(session.options.port, 1234);
 			assert.equal(session.options.host, '127.0.0.1');
 		});
@@ -96,20 +122,20 @@ describe('Session', function() {
 			var session = smpp.connect('smpp://127.0.0.1:1234');
 			assert.equal(session.options.port, 1234);
 			assert.equal(session.options.host, '127.0.0.1');
-			var session = smpp.connect('ssmpp://localhost');
+			session = smpp.connect('ssmpp://localhost');
 			assert(session.options.tls);
-			var session = smpp.connect({ url: 'ssmpp://127.0.0.1:1234'});
+			session = smpp.connect({ url: 'ssmpp://127.0.0.1:1234'});
 			assert(session.options.tls);
 			assert.equal(session.options.port, 1234);
 			assert.equal(session.options.host, '127.0.0.1');
 		});
 
 		it('should successfully establish a connection', function(done) {
-			var session = smpp.connect({ port: port }, done);
+			smpp.connect({ port: port }, done);
 		});
 
 		it('should successfully establish a secure connection', function(done) {
-			var session = smpp.connect({
+			smpp.connect({
 				port: secure.port,
 				tls: true,
 				rejectUnauthorized: false
@@ -118,15 +144,191 @@ describe('Session', function() {
 	});
 
 	describe('#send()', function() {
-		it('should successfully send a pdu and receive its response', function(done) {
-			var session = smpp.connect({ port: port });
-			var pdu = new smpp.PDU('enquire_link');
-			session.send(pdu, done.bind(this, null));
+		it('should successfully send a pdu', function(done) {
+			var session = smpp.connect({ port: port }, function() {
+				var pdu = new smpp.PDU('enquire_link');
+				session.send(pdu, done.bind(this, null));
+			});
 		});
 
 		it('should successfully send a pdu using shorthand methods', function(done) {
-			var session = smpp.connect({ port: port, auto_enquire_link_period:10000 });
-			session.enquire_link(done.bind(this, null));
+			var session = smpp.connect({ port: port, auto_enquire_link_period:10000 }, function() {
+				session.enquire_link(done.bind(this, null));
+			});
+		});
+
+		it('should successfully send a pdu on a secure connection', function(done) {
+			var session = smpp.connect({
+				port: secure.port,
+				tls: true,
+				rejectUnauthorized: false
+			}, function() {
+				session.enquire_link(done.bind(this, null));
+			});
+		});
+
+		it('should successfully send a pdu and receive its response', function(done) {
+			var session = smpp.connect({ port: port }, function() {
+				session.submit_sm({
+					destination_addr: "+01123456789",
+					short_message: "Hello!"
+				}, function(pdu) {
+					assert.equal(pdu.command, "submit_sm_resp");
+					assert.equal(pdu.command_status, smpp.ESME_ROK);
+					assert.equal(pdu.message_id, "123456789 sent to +01123456789");
+					done();
+				});
+			});
+		});
+
+		it('should successfully receive matching responses for any pdu sent with a generic autoreply server handler', function(done) {
+			var session = smpp.connect({ port: autoresponder.port}, function() {
+				session.bind_transceiver({}, function(pdu) {
+					assert.equal(pdu.command, "bind_transceiver_resp");
+					session.bind_receiver({}, function(pdu) {
+						assert.equal(pdu.command, "bind_receiver_resp");
+						session.bind_transmitter({}, function(pdu) {
+							assert.equal(pdu.command, "bind_transmitter_resp");
+							done();
+						});
+					});
+				});
+			});
+		});
+
+	});
+
+});
+
+describe('Client/Server simulations', function() {
+
+	var server, port, debugBuffer = [];
+
+	before(function (done) {
+		server = smpp.createServer({}, function (session) {
+			debugBuffer = [];
+			// We'll use the debug event to track what happened inside the server
+			session.on('debug', function(type, msg, payload) {
+				debugBuffer.push({type: type, msg: msg, payload: payload});
+			});
+			session.on('submit_sm', function (pdu) {
+				var response = pdu.response();
+				response.message_id = "123456789 sent to " + pdu.destination_addr; // Injected to verify the data received by the server
+				session.send(response);
+			});
+			session.on('bind_transceiver', function (pdu) {
+				// pause the session to prevent further incoming pdu events,
+				// untill we authorize the session with some async operation.
+				session.pause();
+				var checkAsyncUserPass = function (user, pwd, onComplete) {
+					setTimeout(function () {
+						if (user === "FAKE_USER" && pwd === "FAKE_PASSWORD") {
+							onComplete();
+						} else {
+							onComplete("invalid user and password combination");
+						}
+					}, 25); // Delayed processing simulation
+				};
+				checkAsyncUserPass(pdu.system_id, pdu.password, function (err) {
+					if (err) {
+						session.send(pdu.response({ command_status: smpp.ESME_RBINDFAIL}));
+						session.close();
+					} else {
+						session.send(pdu.response());
+						session.resume();
+					}
+				});
+			});
+		});
+		server.listen(0, done);
+		port = server.address().port;
+	});
+
+	after(function (done) {
+		server.sessions.forEach(function (session) {
+			session.close();
+		});
+		server.close(done);
+	});
+
+	it('should successfully bind a transceiver with a hardcoded user/password', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.bind_transceiver({
+				system_id: 'FAKE_USER',
+				password: 'FAKE_PASSWORD'
+			}, function (pdu) {
+				assert.equal(pdu.command, "bind_transceiver_resp");
+				assert.equal(pdu.command_status, smpp.ESME_ROK);
+				// send fake message
+				session.submit_sm({
+					destination_addr: "+01123456789",
+					short_message: "Hello!"
+				}, function(pdu) {
+					assert.equal(pdu.command, "submit_sm_resp");
+					assert.equal(pdu.command_status, smpp.ESME_ROK);
+					assert.equal(pdu.message_id, "123456789 sent to +01123456789");
+					done();
+				});
+			});
 		});
 	});
+
+	it('should fail to bind a transceiver with a wrong hardcoded user/password', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.bind_transceiver({
+				system_id: 'FAKE_USER_INVALID',
+				password: 'FAKE_PASSWORD_INVALID'
+			}, function (pdu) {
+				assert.equal(pdu.command, "bind_transceiver_resp");
+				assert.equal(pdu.command_status, smpp.ESME_RBINDFAIL);
+				done();
+			});
+		});
+	});
+
+	it('should successfully emit every expected debug log entry', function (done) {
+		var session = smpp.connect({port: port}, function () {
+			session.bind_transceiver({
+				system_id: 'FAKE_USER',
+				password: 'FAKE_PASSWORD'
+			}, function (pdu) {
+				assert.equal(pdu.command, "bind_transceiver_resp");
+				assert.equal(pdu.command_status, smpp.ESME_ROK);
+
+				// Read the server debug entries to find the relevant types that should have been emitted.
+				var debugEntry, i;
+
+				assert.notEqual(debugBuffer.length, 0, "Debug log is empty");
+
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.in") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "pdu.command.in entry not found in debug log");
+				assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver", "bind_transceiver command not found in log");
+
+				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.out") debugEntry = debugBuffer[i];
+				assert.notEqual(debugEntry, null, "pdu.command.out entry not found in debug log");
+				assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver_resp", "bind_transceiver_resp command not found in log");
+
+				done();
+			});
+		});
+	});
+
+	it('should fail to connect with an invalid port and trigger a ECONNREFUSED error', function (done) {
+		var session = smpp.connect({port: 27750}, function () {});
+		session.on('error', function(e) {
+			// empty callback to catch emitted errors to prevent exit due unhandled errors
+			assert.equal(e.code, "ECONNREFUSED");
+			done();
+		});
+	});
+
+	it('should fail to connect with an invalid host and trigger a EAI_AGAIN, ENOTFOUND or ESRCH error', function (done) {
+		var session = smpp.connect({url: 'smpp://unknownhost:2775'}, function () {});
+		session.on('error', function(e) {
+			// empty callback to catch emitted errors to prevent exit due unhandled errors
+			assert.notEqual(-1, ["EAI_AGAIN", "ENOTFOUND", "ESRCH"].indexOf(e.code));
+			done();
+		});
+	});
+
 });


### PR DESCRIPTION
Not having debug information makes it very difficult to debug communication issues between client & server. 

This PR implements a pretty standard debug log that can be activated with a simple `debug: true` option. By default, the debug log is disabled, there won't be any output to stdout.

Additionally, the session object emits debug events in both client & server (even with the debug option disabled)

Tests to check the debug events have been written. Also, some new tests to perform client/server simulations are included.