### PR TITLE
Minor improvements to SMPP Session & new SMPP Tests.

### DIFF
--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -15,6 +15,7 @@ function Session(options) {
 	this._extractPDUs = this._extractPDUs.bind(self);
 	this.sequence = 0;
 	this.paused = false;
+	this.closed = false;
 	this.remoteAddress = null;
 	this._busy = false;
 	this._callbacks = {};
@@ -71,6 +72,7 @@ function Session(options) {
 		self._extractPDUs();
 	});
 	this.socket.on('close', function() {
+		self.closed = true;
 		clearTimeout(connectTimeout);
 		if (self._mode === "server") {
 			self.debug("client.disconnected", "client has disconnected");
@@ -209,14 +211,22 @@ Session.prototype.resume = function() {
 
 Session.prototype.close = function(callback) {
 	if (callback) {
-		this.socket.once('close', callback);
+		if (this.closed) {
+			this.socket.once('close', callback);
+		} else {
+			callback();
+		}
 	}
 	this.socket.end();
 };
 
 Session.prototype.destroy = function(callback) {
 	if (callback) {
-		this.socket.once('close', callback);
+		if (this.closed) {
+			this.socket.once('close', callback);
+		} else {
+			callback();
+		}
 	}
 	this.socket.destroy();
 };
@@ -333,7 +343,9 @@ exports.connect = exports.createSession = function(url, listener) {
 
 	var session = new Session(options);
 	if (listener) {
-		session.on(options.tls ? 'secureConnect' : 'connect', listener);
+		session.on(options.tls ? 'secureConnect' : 'connect', function() {
+			listener(session);
+		});
 	}
 
 	return session;

--- a/test/smpp.js
+++ b/test/smpp.js
@@ -55,19 +55,19 @@ describe('Session', function() {
 		});
 	};
 
-	before(function(done) {
+	beforeEach(function(done) {
 		server = smpp.createServer({}, sessionHandler);
 		server.listen(0, done);
 		port = server.address().port;
 	});
 
-	before(function(done) {
+	beforeEach(function(done) {
 		autoresponder.server = smpp.createServer({}, sessionHandlerAutoresponder);
 		autoresponder.server.listen(0, done);
 		autoresponder.port = autoresponder.server.address().port;
 	});
 
-	before(function(done) {
+	beforeEach(function(done) {
 		secure.server = smpp.createServer({
 			key: fs.readFileSync(__dirname + '/fixtures/server.key'),
 			cert: fs.readFileSync(__dirname + '/fixtures/server.crt')
@@ -76,21 +76,21 @@ describe('Session', function() {
 		secure.port = secure.server.address().port;
 	});
 
-	after(function(done) {
+	afterEach(function(done) {
 		server.sessions.forEach(function(session) {
 			session.close();
 		});
 		server.close(done);
 	});
 
-	after(function(done) {
+	afterEach(function(done) {
 		autoresponder.server.sessions.forEach(function(session) {
 			session.close();
 		});
 		autoresponder.server.close(done);
 	});
 
-	after(function(done) {
+	afterEach(function(done) {
 		secure.server.sessions.forEach(function(session) {
 			session.close();
 		});
@@ -131,7 +131,9 @@ describe('Session', function() {
 		});
 
 		it('should successfully establish a connection', function(done) {
-			smpp.connect({ port: port }, done);
+			smpp.connect({ port: port }, function() {
+				done();
+			});
 		});
 
 		it('should successfully establish a secure connection', function(done) {
@@ -139,7 +141,9 @@ describe('Session', function() {
 				port: secure.port,
 				tls: true,
 				rejectUnauthorized: false
-			}, done);
+			}, function() {
+				done();
+			});
 		});
 	});
 
@@ -202,143 +206,221 @@ describe('Session', function() {
 
 describe('Client/Server simulations', function() {
 
-	var server, port, debugBuffer = [];
+	describe('standard connection simulations', function() {
 
-	before(function (done) {
-		server = smpp.createServer({}, function (session) {
-			debugBuffer = [];
-			// We'll use the debug event to track what happened inside the server
-			session.on('debug', function(type, msg, payload) {
-				debugBuffer.push({type: type, msg: msg, payload: payload});
-			});
-			session.on('submit_sm', function (pdu) {
-				var response = pdu.response();
-				response.message_id = "123456789 sent to " + pdu.destination_addr; // Injected to verify the data received by the server
-				session.send(response);
-			});
-			session.on('bind_transceiver', function (pdu) {
-				// pause the session to prevent further incoming pdu events,
-				// untill we authorize the session with some async operation.
-				session.pause();
-				var checkAsyncUserPass = function (user, pwd, onComplete) {
-					setTimeout(function () {
-						if (user === "FAKE_USER" && pwd === "FAKE_PASSWORD") {
-							onComplete();
+		var server, port, debugBuffer = [], lastServerError;
+
+		beforeEach(function (done) {
+			server = smpp.createServer({}, function (session) {
+				debugBuffer = [];
+				// We'll use the debug event to track what happened inside the server
+				session.on('debug', function(type, msg, payload) {
+					debugBuffer.push({type: type, msg: msg, payload: payload});
+				});
+				session.on('submit_sm', function (pdu) {
+					var response = pdu.response();
+					response.message_id = "123456789 sent to " + pdu.destination_addr; // Injected to verify the data received by the server
+					session.send(response);
+				});
+				session.on('bind_transceiver', function (pdu) {
+					// pause the session to prevent further incoming pdu events,
+					// untill we authorize the session with some async operation.
+					session.pause();
+					var checkAsyncUserPass = function (user, pwd, onComplete) {
+						setTimeout(function () {
+							if (user === "FAKE_USER" && pwd === "FAKE_PASSWORD") {
+								onComplete();
+							} else {
+								onComplete("invalid user and password combination");
+							}
+						}, 25); // Delayed processing simulation
+					};
+					checkAsyncUserPass(pdu.system_id, pdu.password, function (err) {
+						if (err) {
+							session.send(pdu.response({ command_status: smpp.ESME_RBINDFAIL}));
+							session.close();
 						} else {
-							onComplete("invalid user and password combination");
+							session.send(pdu.response());
+							session.resume();
 						}
-					}, 25); // Delayed processing simulation
-				};
-				checkAsyncUserPass(pdu.system_id, pdu.password, function (err) {
-					if (err) {
-						session.send(pdu.response({ command_status: smpp.ESME_RBINDFAIL}));
-						session.close();
-					} else {
-						session.send(pdu.response());
-						session.resume();
-					}
+					});
+				});
+				// Errors
+				session.on('error', function (err) {
+					lastServerError = err;
+					session.close();
+				});
+			});
+			server.listen(0, done);
+			port = server.address().port;
+		});
+
+		afterEach(function (done) {
+			server.sessions.forEach(function (session) {
+				session.close();
+			});
+			server.close(done);
+		});
+
+		it('should successfully bind a transceiver with a hardcoded user/password', function (done) {
+			var session = smpp.connect({port: port}, function () {
+				session.bind_transceiver({
+					system_id: 'FAKE_USER',
+					password: 'FAKE_PASSWORD'
+				}, function (pdu) {
+					assert.equal(pdu.command, "bind_transceiver_resp");
+					assert.equal(pdu.command_status, smpp.ESME_ROK);
+					// send fake message
+					session.submit_sm({
+						destination_addr: "+01123456789",
+						short_message: "Hello!"
+					}, function (pdu) {
+						assert.equal(pdu.command, "submit_sm_resp");
+						assert.equal(pdu.command_status, smpp.ESME_ROK);
+						assert.equal(pdu.message_id, "123456789 sent to +01123456789");
+						done();
+					});
 				});
 			});
 		});
-		server.listen(0, done);
-		port = server.address().port;
-	});
 
-	after(function (done) {
-		server.sessions.forEach(function (session) {
-			session.close();
-		});
-		server.close(done);
-	});
-
-	it('should successfully bind a transceiver with a hardcoded user/password', function (done) {
-		var session = smpp.connect({port: port}, function () {
-			session.bind_transceiver({
-				system_id: 'FAKE_USER',
-				password: 'FAKE_PASSWORD'
-			}, function (pdu) {
-				assert.equal(pdu.command, "bind_transceiver_resp");
-				assert.equal(pdu.command_status, smpp.ESME_ROK);
-				// send fake message
-				session.submit_sm({
-					destination_addr: "+01123456789",
-					short_message: "Hello!"
-				}, function(pdu) {
-					assert.equal(pdu.command, "submit_sm_resp");
-					assert.equal(pdu.command_status, smpp.ESME_ROK);
-					assert.equal(pdu.message_id, "123456789 sent to +01123456789");
+		it('should fail to bind a transceiver with a wrong hardcoded user/password', function (done) {
+			var session = smpp.connect({port: port}, function () {
+				session.bind_transceiver({
+					system_id: 'FAKE_USER_INVALID',
+					password: 'FAKE_PASSWORD_INVALID'
+				}, function (pdu) {
+					assert.equal(pdu.command, "bind_transceiver_resp");
+					assert.equal(pdu.command_status, smpp.ESME_RBINDFAIL);
 					done();
 				});
 			});
 		});
-	});
 
-	it('should fail to bind a transceiver with a wrong hardcoded user/password', function (done) {
-		var session = smpp.connect({port: port}, function () {
-			session.bind_transceiver({
-				system_id: 'FAKE_USER_INVALID',
-				password: 'FAKE_PASSWORD_INVALID'
-			}, function (pdu) {
-				assert.equal(pdu.command, "bind_transceiver_resp");
-				assert.equal(pdu.command_status, smpp.ESME_RBINDFAIL);
+		it('should successfully emit every expected debug log entry', function (done) {
+			var session = smpp.connect({port: port}, function () {
+				session.bind_transceiver({
+					system_id: 'FAKE_USER',
+					password: 'FAKE_PASSWORD'
+				}, function (pdu) {
+					assert.equal(pdu.command, "bind_transceiver_resp");
+					assert.equal(pdu.command_status, smpp.ESME_ROK);
+
+					// Read the server debug entries to find the relevant types that should have been emitted.
+					var debugEntry, i;
+
+					assert.notEqual(debugBuffer.length, 0, "Debug log is empty");
+
+					for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.in") debugEntry = debugBuffer[i];
+					assert.notEqual(debugEntry, null, "pdu.command.in entry not found in debug log");
+					assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver", "bind_transceiver command not found in log");
+
+					for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.out") debugEntry = debugBuffer[i];
+					assert.notEqual(debugEntry, null, "pdu.command.out entry not found in debug log");
+					assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver_resp", "bind_transceiver_resp command not found in log");
+
+					done();
+				});
+			});
+		});
+
+		it('should fail to connect with an invalid port and trigger a ECONNREFUSED error', function (done) {
+			var session = smpp.connect({port: 27750}, function () {});
+			session.on('error', function (e) {
+				// empty callback to catch emitted errors to prevent exit due unhandled errors
+				assert.equal(e.code, "ECONNREFUSED");
 				done();
 			});
 		});
-	});
 
-	it('should successfully emit every expected debug log entry', function (done) {
-		var session = smpp.connect({port: port}, function () {
-			session.bind_transceiver({
-				system_id: 'FAKE_USER',
-				password: 'FAKE_PASSWORD'
-			}, function (pdu) {
-				assert.equal(pdu.command, "bind_transceiver_resp");
-				assert.equal(pdu.command_status, smpp.ESME_ROK);
-
-				// Read the server debug entries to find the relevant types that should have been emitted.
-				var debugEntry, i;
-
-				assert.notEqual(debugBuffer.length, 0, "Debug log is empty");
-
-				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.in") debugEntry = debugBuffer[i];
-				assert.notEqual(debugEntry, null, "pdu.command.in entry not found in debug log");
-				assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver", "bind_transceiver command not found in log");
-
-				for (i = 0, debugEntry = null; i < debugBuffer.length && debugEntry === null; i++) if (debugBuffer[i].type === "pdu.command.out") debugEntry = debugBuffer[i];
-				assert.notEqual(debugEntry, null, "pdu.command.out entry not found in debug log");
-				assert.equal(debugEntry ? debugEntry.msg : null, "bind_transceiver_resp", "bind_transceiver_resp command not found in log");
-
+		it('should fail to connect with an invalid host and trigger a EAI_AGAIN, ENOTFOUND or ESRCH error', function (done) {
+			var session = smpp.connect({url: 'smpp://unknownhost:2775'});
+			session.on('error', function (e) {
+				// empty callback to catch emitted errors to prevent exit due unhandled errors
+				assert.notEqual(-1, ["EAI_AGAIN", "ENOTFOUND", "ESRCH"].indexOf(e.code));
 				done();
 			});
 		});
-	});
 
-	it('should fail to connect with an invalid port and trigger a ECONNREFUSED error', function (done) {
-		var session = smpp.connect({port: 27750}, function () {});
-		session.on('error', function(e) {
-			// empty callback to catch emitted errors to prevent exit due unhandled errors
-			assert.equal(e.code, "ECONNREFUSED");
-			done();
+		it('should fail to connect with an invalid host and trigger a ETIMEOUT error', function (done) {
+			var session = smpp.connect({url: 'smpp://1.1.1.1:2775', connectTimeout: 25});
+			session.on('error', function (e) {
+				// empty callback to catch emitted errors to prevent exit due unhandled errors
+				assert.equal(e.code, "ETIMEOUT");
+				done();
+			});
 		});
-	});
 
-	it('should fail to connect with an invalid host and trigger a EAI_AGAIN, ENOTFOUND or ESRCH error', function (done) {
-		var session = smpp.connect({url: 'smpp://unknownhost:2775'}, function () {});
-		session.on('error', function(e) {
-			// empty callback to catch emitted errors to prevent exit due unhandled errors
-			assert.notEqual(-1, ["EAI_AGAIN", "ENOTFOUND", "ESRCH"].indexOf(e.code));
-			done();
+		it('should fail to connect with an invalid host and trigger a ETIMEOUT error', function (done) {
+			var session = smpp.connect({url: 'smpp://1.1.1.1:2775', connectTimeout: 25});
+			session.on('error', function (e) {
+				// empty callback to catch emitted errors to prevent exit due unhandled errors
+				assert.equal(e.code, "ETIMEOUT");
+				done();
+			});
 		});
+
 	});
 
-	it('should fail to connect with an invalid host and trigger a ETIMEOUT error', function (done) {
-		var session = smpp.connect({url: 'smpp://1.1.1.1:2775', connectTimeout: 25}, function () {});
-		session.on('error', function(e) {
-			// empty callback to catch emitted errors to prevent exit due unhandled errors
-			assert.equal(e.code, "ETIMEOUT");
-			done();
+
+	describe('heavy load simulations', function() {
+
+		var server, port, lastServerError;
+
+		beforeEach(function (done) {
+			server = smpp.createServer({}, function (session) {
+				session.on('bind_transceiver', function (pdu) {
+					session.pause();
+					setTimeout(function () {
+						session.resume();
+						session.send(pdu.response());
+					}, 25); // Delayed processing simulation
+				});
+				// Errors
+				session.on('error', function (err) {
+					lastServerError = err;
+					session.close();
+				});
+			});
+			server.listen(0, done);
+			port = server.address().port;
 		});
-	});
 
+		afterEach(function (done) {
+			server.sessions.forEach(function (session) {
+				session.close();
+			});
+			server.close(done);
+		});
+
+		it('should successfully have multiple sessions opened at the same time, closing them all afterwards', function (done) {
+			var totalConnections = 500;
+			var closedConnections = 0;
+			for (var i = 0; i < totalConnections; i++) {
+				smpp.connect({port: port}, function (session) {
+					session.bind_transceiver({}, function (pdu) {
+						assert.equal(pdu.command, "bind_transceiver_resp");
+						session.close(function () {
+							closedConnections++;
+						});
+					});
+				});
+			}
+			var interval = setInterval( function() {
+				var openConnections = 0;
+				server.sessions.forEach(function (session) {
+					if (!session.closed) openConnections++;
+				});
+				// Check if all sessions have been closed
+				if (openConnections === 0 && closedConnections === totalConnections && server.sessions.length === 0) {
+					clearInterval(interval);
+					done(); // Test ok
+				}
+			}, 10);
+
+		});
+
+
+	});
 
 });


### PR DESCRIPTION
Minor improvements to SMPP Session & new SMPP Tests.

# 1. SMPP Session: 
- 1.1 Mark session as closed once the socket close event is triggered. This allows the close & destroy methods to trigger the callbacks even if the session has already been close.
- 1.2 Inject session parameter on the connect(callback) (smpp.js line 397) This makes smpp.createServer & smpp.connect behave on a similar way, providing their callbacks with the session parameter. **Potential issue**: this could affect someone expecting an error on the connect callback, but that functionality wasn't documented and an error was actually never sent because connect & secureConnect events are emitted without any parameters. I consider it should be standarized.

# 2. SMPP Tests: 
- 2.1 Reset server on each individual test.
- 2.2 Heavy load simulation: 500 connections, bind_transceiver (async) and disconnections that should happen in less than 2 seconds.
- 2.3 Fix a few tests to trigger done manually without any parameter (1.2 now injects the session as parameter and done expects an error parameter in case it fails, i.e: test/smpp.js line 160)