### PR TITLE
Update lib/defs.js types.cstring

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -47,14 +47,14 @@ var types = {
 			return buffer.toString('ascii', offset, offset + length);
 		},
 		write: function(value, buffer, offset) {
-			buffer.writeUInt8(value.length, offset++);
-			if (typeof value == 'string') {
-				value = Buffer.from(value, 'ascii');
+			if (!Buffer.isBuffer(value)) {
+				value = Buffer.from(String(value), 'ascii');
 			}
+			buffer.writeUInt8(value.length, offset++);
 			value.copy(buffer, offset);
 		},
 		size: function(value) {
-			return value.length + 1;
+			return (value.length ?? String(value).length) + 1;
 		},
 		default: ''
 	},
@@ -67,14 +67,14 @@ var types = {
 			return buffer.toString('ascii', offset, offset + length);
 		},
 		write: function(value, buffer, offset) {
-			if (typeof value == 'string') {
-				value = Buffer.from(value, 'ascii');
+			if (!Buffer.isBuffer(value)) {
+				value = Buffer.from(String(value), 'ascii');
 			}
 			value.copy(buffer, offset);
 			buffer[offset + value.length] = 0;
 		},
 		size: function(value) {
-			return value.length + 1;
+			return (value.length ?? String(value).length) + 1;
 		},
 		default: ''
 	},


### PR DESCRIPTION
Prevents a crash when a сstring PDU filed contains a value of a different type. For example, if the address field contains a number.