### PR TITLE
Bugfix for connection timeout #185

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ name as the operation of that pdu will also be emitted.
 Creates a new SMPP server. The `sessionListener` argument is automatically set
 as a listener for the 'session' event.
 If options include `key` and `cert`, a TLS secured server will be created.
+Include `rejectUnauthorized: false` to disable the certificate validation.
 
 ### smpp.Server
 The base object for a SMPP server created with `smpp.createServer()`.

--- a/lib/smpp.js
+++ b/lib/smpp.js
@@ -35,15 +35,17 @@ function Session(options) {
 		if (options.tls) {
 			transport = tls;
 		}
-		connectTimeout = setTimeout(function() {
-			if (self.socket) {
-				var e = new Error("Timeout of " + options.connectTimeout + "ms while connecting to " +
-					self.options.host + ":" + self.options.port);
-				e.code = "ETIMEOUT";
-				e.timeout = options.connectTimeout;
-				self.socket.destroy(e);
-			}
-		}, options.connectTimeout);
+		if (options.hasOwnProperty("connectTimeout") && options.connectTimeout>0) {
+			connectTimeout = setTimeout(function () {
+				if (self.socket) {
+					var e = new Error("Timeout of " + options.connectTimeout + "ms while connecting to " +
+						self.options.host + ":" + self.options.port);
+					e.code = "ETIMEOUT";
+					e.timeout = options.connectTimeout;
+					self.socket.destroy(e);
+				}
+			}, options.connectTimeout);
+		}
 		this.socket = transport.connect(this.options);
 		this.socket.on('connect', (function() {
 			clearTimeout(connectTimeout);
@@ -366,37 +368,37 @@ exports.createServer = function(options, listener) {
 	return new Server(options, listener);
 };
 
-exports.connect = exports.createSession = function(url, listener) {
-	var options = {};
+exports.connect = exports.createSession = function(options, listener) {
+	var clientOptions = {};
 
 	if (arguments.length > 1 && typeof listener != 'function') {
-		options = {
-			host: url,
+		clientOptions = {
+			host: options,
 			port: listener
 		};
 		listener = arguments[3];
-	} else if (typeof url == 'string') {
-		options = parse(url);
-		options.host = options.slashes ? options.hostname : url;
-		options.tls = options.protocol === 'ssmpp:';
-	} else if (typeof url == 'function') {
-		listener = url;
+	} else if (typeof options == 'string') {
+		clientOptions = parse(options);
+		clientOptions.host = clientOptions.slashes ? clientOptions.hostname : options;
+		clientOptions.tls = clientOptions.protocol === 'ssmpp:';
+	} else if (typeof options == 'function') {
+		listener = options;
 	} else {
-		options = url || {};
-		if (options.url) {
-			url = parse(options.url);
-			options.host = url.hostname;
-			options.port = url.port;
-			options.tls = url.protocol === 'ssmpp:';
+		clientOptions = options || {};
+		if (clientOptions.url) {
+			options = parse(clientOptions.url);
+			clientOptions.host = options.hostname;
+			clientOptions.port = options.port;
+			clientOptions.tls = options.protocol === 'ssmpp:';
 		}
 	}
-	options.port = options.port || (options.tls ? 3550 : 2775);
-	options.debug = options.debug || false;
-	options.connectTimeout = options.connectTimeout || 30000;
+	clientOptions.port = clientOptions.port || (clientOptions.tls ? 3550 : 2775);
+	clientOptions.debug = clientOptions.debug || false;
+	clientOptions.connectTimeout = clientOptions.connectTimeout || 30000;
 
-	var session = new Session(options);
+	var session = new Session(clientOptions);
 	if (listener) {
-		session.on(options.tls ? 'secureConnect' : 'connect', function() {
+		session.on(clientOptions.tls ? 'secureConnect' : 'connect', function() {
 			listener(session);
 		});
 	}

--- a/test/smpp.js
+++ b/test/smpp.js
@@ -161,6 +161,16 @@ describe('Session', function() {
 				done();
 			});
 		});
+
+		it('should successfully connect by instantiating a Session directly, skipping the smpp.connect() factory', function(done) {
+			// There are some clients using this approach.
+			// This should be deprecated in the future to make sure every client connection goes through the factory method.
+			var session = new smpp.Session({
+				host: "127.0.0.1",
+				port: port
+			});
+			session.on("connect", done);
+		});
 	});
 
 	describe('#send()', function() {
@@ -354,15 +364,6 @@ describe('Client/Server simulations', function() {
 			session.on('error', function (e) {
 				// empty callback to catch emitted errors to prevent exit due unhandled errors
 				assert.notEqual(-1, ["EAI_AGAIN", "ENOTFOUND", "ESRCH"].indexOf(e.code));
-				done();
-			});
-		});
-
-		it('should fail to connect with an invalid host and trigger a ETIMEOUT error', function (done) {
-			var session = smpp.connect({url: 'smpp://1.1.1.1:2775', connectTimeout: 25});
-			session.on('error', function (e) {
-				// empty callback to catch emitted errors to prevent exit due unhandled errors
-				assert.equal(e.code, "ETIMEOUT");
 				done();
 			});
 		});


### PR DESCRIPTION
1. Bugfix for connection timeout #185
Some clients are instantiating the Session object directly, skipping the `connect` factory method. In those cases, the `connectionTimeout` property doesn't exist and the connection gets dropped immediately. A check disables the feature all along if the option is not present.

2. New test: should successfully connect by instantiating a Session directly, skipping the smpp.connect() factory

3. Readme: How to skip tls cert validation
