### PR TITLE
Use nyc for code coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
+.nyc_output/
 package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ node_js:
   - 16
 
 script:
-  - npm run-script cover
+  - npm run test_coverage
 
 after_script:
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
     "index.js"
   ],
   "scripts": {
-    "cover": "istanbul cover _mocha",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "test_coverage": "nyc --reporter=text mocha",
     "test": "mocha"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",
-    "istanbul": "^0.4.3",
-    "mocha": "2.x"
+    "mocha": "2.x",
+    "nyc": "^12.0.2"
   },
   "dependencies": {
     "findhit-proxywrap": "^0.3.12",


### PR DESCRIPTION
npm WARN deprecated istanbul@0.4.5: This module is no longer maintained, try this instead:
npm WARN deprecated   npm i nyc
npm WARN deprecated Visit https://istanbul.js.org/integrations for other alternatives.