### PR TITLE
Fix message encode crash, DCS-aware decode, and user-defined TLV round-trip

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -505,6 +505,14 @@ filters.message = {
 		if (Buffer.isBuffer(value)) {
 			return value;
 		}
+		// Tolerate non-string scalars (e.g. a numeric short_message) and
+		// null/undefined, which previously threw "Cannot read properties of
+		// undefined (reading 'message')" (issues #229, #256).
+		if (value === null || value === undefined) {
+			value = '';
+		} else if (typeof value === 'number' || typeof value === 'boolean') {
+			value = String(value);
+		}
 		var message = typeof value === 'string' ? value : value.message;
 		if (typeof message === 'string' && message) {
 			var encoded = false;
@@ -548,7 +556,24 @@ filters.message = {
 		if (!Buffer.isBuffer(value) || !('data_coding' in this)) {
 			return value;
 		}
-		var encoding = this.data_coding & 0x0F;
+		// Resolve the encoding from the full Data Coding Scheme (DCS) byte, not
+		// just the low nibble. The naive `data_coding & 0x0F` is wrong when the
+		// DCS carries message-class / MWI / compression bits in the high nibble
+		// (GSM 03.38), causing mis-decoded / empty messages (issues #66, #252).
+		var dc = this.data_coding;
+		var enc = 0;
+		if (dc <= 0x0E) {
+			enc = dc & 0x0F;
+		} else if ((dc & 0xF0) === 0xF0) {
+			enc = (dc & 0x04) ? consts.ENCODING.BINARY : consts.ENCODING.ASCII;
+		} else if ((dc & 0xC0) === 0x00) {
+			var mode = (dc & 0x0C) >> 2;
+			enc = mode === 1 ? consts.ENCODING.BINARY :
+				mode === 2 ? consts.ENCODING.UCS2 : consts.ENCODING.ASCII;
+		} else if ((dc & 0xC0) === 0xC0) {
+			enc = ((dc & 0xE0) === 0xE0) ? consts.ENCODING.UCS2 : consts.ENCODING.ASCII;
+		}
+		var encoding = enc;
 		if (!encoding) {
 			encoding = encodings.default;
 		} else {

--- a/lib/pdu.js
+++ b/lib/pdu.js
@@ -12,6 +12,22 @@ var pduHeadParams = [
 	'sequence_number'
 ];
 
+// A user-defined / unknown TLV is addressed by its numeric tag id (e.g. 0x3C02)
+// which becomes a numeric-string key on the PDU. Treat such keys as raw TLVs so
+// they round-trip on encode, not only on decode (issue #231).
+function isRawTlvKey(key, params) {
+	if (!/^[0-9]+$/.test(key)) return false;
+	var id = Number(key);
+	if (id < 0 || id > 0xFFFF) return false;
+	return !(key in params) && !tlvs[key];
+}
+
+function toRawTlvBuffer(value) {
+	if (Buffer.isBuffer(value)) return value;
+	if (value === null || value === undefined) return Buffer.alloc(0);
+	return Buffer.from(String(value), 'ascii');
+}
+
 function PDU(command, options) {
 	if (Buffer.isBuffer(command)) {
 		return this.fromBuffer(command);
@@ -37,6 +53,10 @@ function PDU(command, options) {
 	}
 	for (var key in options) if (key in tlvs && !(key in params)) {
 		this[key] = options[key];
+	}
+	// user-defined / unknown TLVs addressed by numeric tag id (issue #231)
+	for (var rkey in options) if (isRawTlvKey(rkey, params)) {
+		this[rkey] = options[rkey];
 	}
 }
 
@@ -184,6 +204,9 @@ PDU.prototype.toBuffer = function() {
 			values.forEach(function(value) {
 				this.command_length += tlvs[key].type.size(value) + 4;
 			}.bind(this));
+		} else if (isRawTlvKey(key, params)) {
+			// user-defined / unknown TLV by numeric tag id (issue #231)
+			this.command_length += toRawTlvBuffer(this[key]).length + 4;
 		}
 	}
 	var buffer = this._initBuffer();
@@ -204,6 +227,15 @@ PDU.prototype.toBuffer = function() {
 			tlvs[key].type.write(value, buffer, offset);
 			offset += length;
 		});
+	}
+	for (var rkey in this) if (isRawTlvKey(rkey, params)) {
+		// user-defined / unknown TLV by numeric tag id (issue #231)
+		var raw = toRawTlvBuffer(this[rkey]);
+		buffer.writeUInt16BE(Number(rkey), offset);
+		buffer.writeUInt16BE(raw.length, offset + 2);
+		offset += 4;
+		raw.copy(buffer, offset);
+		offset += raw.length;
 	}
 	return buffer;
 };

--- a/test/fixes.js
+++ b/test/fixes.js
@@ -1,0 +1,66 @@
+var assert = require('assert'),
+	smpp = require('..'),
+	PDU = require('../lib/pdu').PDU,
+	Buffer = require('safer-buffer').Buffer;
+
+describe('issue fixes', function () {
+
+	describe('#229 / #256 - tolerant short_message encoding', function () {
+		it('does not crash when short_message is a number', function () {
+			var pdu = new PDU('submit_sm', { destination_addr: '12345', short_message: 123 });
+			var buf;
+			assert.doesNotThrow(function () { buf = pdu.toBuffer(); });
+			assert.equal(new PDU(buf).short_message.message, '123');
+		});
+
+		it('does not crash when short_message is undefined', function () {
+			var pdu = new PDU('submit_sm', { destination_addr: '12345' });
+			pdu.short_message = undefined;
+			assert.doesNotThrow(function () { pdu.toBuffer(); });
+		});
+
+		it('does not crash when short_message is null', function () {
+			var pdu = new PDU('submit_sm', { destination_addr: '12345', short_message: null });
+			assert.doesNotThrow(function () { pdu.toBuffer(); });
+		});
+	});
+
+	describe('#66 / #252 - DCS-aware encoding detection on decode', function () {
+		function decodeWith(data_coding, buffer) {
+			return smpp.filters.message.decode.call({ data_coding: data_coding, esm_class: 0 }, buffer, false);
+		}
+
+		it('decodes UCS2 (data_coding 0x08)', function () {
+			assert.equal(decodeWith(0x08, smpp.encodings.UCS2.encode('héllo')).message, 'héllo');
+		});
+
+		it('treats DCS 0xF8 as default alphabet, not UCS2 (low-nibble trap)', function () {
+			assert.equal(decodeWith(0xF8, smpp.encodings.ASCII.encode('test')).message, 'test');
+		});
+
+		it('treats DCS 0xF4 as binary (returns raw buffer)', function () {
+			var out = decodeWith(0xF4, Buffer.from([1, 2, 3])).message;
+			assert.ok(Buffer.isBuffer(out));
+			assert.deepEqual([].slice.call(out), [1, 2, 3]);
+		});
+
+		it('keeps low data_coding values working (0x00 => default ASCII)', function () {
+			assert.equal(decodeWith(0x00, smpp.encodings.ASCII.encode('hi')).message, 'hi');
+		});
+	});
+
+	describe('#231 - user-defined TLVs round-trip by numeric tag', function () {
+		it('round-trips a custom TLV addressed by its numeric tag id', function () {
+			var pdu = new PDU('submit_sm', { destination_addr: '12345', short_message: 'x' });
+			pdu[0x3C02] = Buffer.from('TEST', 'ascii');
+			var round = new PDU(pdu.toBuffer());
+			assert.ok(Buffer.isBuffer(round[0x3C02]));
+			assert.equal(round[0x3C02].toString('ascii'), 'TEST');
+		});
+
+		it('accepts a custom TLV passed via constructor options', function () {
+			var pdu = new PDU('submit_sm', { destination_addr: '12345', short_message: 'x', 15362: Buffer.from('ALEX', 'ascii') });
+			assert.equal(new PDU(pdu.toBuffer())[15362].toString('ascii'), 'ALEX');
+		});
+	});
+});


### PR DESCRIPTION
@
This PR fixes three independent, frequently-reported issues. Each change is small and covered by a regression test (`test/fixes.js`). No API changes.

### `short_message` encode crash — fixes #229, #256
`filters.message.encode` assumed a string or `{message}` object and threw
`TypeError: Cannot read properties of undefined (reading message)` when given a
number, `null`, or `undefined` `short_message`. It now coerces scalars and guards
null/undefined.

### Wrong/empty decode for high Data Coding Scheme values — fixes #66, #252
Decoding used `data_coding & 0x0F`, which mis-detects the charset whenever the DCS
high nibble carries message-class / MWI / compression bits (GSM 03.38). Decoding
now parses the full DCS byte. Low `data_coding` values (0x00–0x0E) are unchanged.

### User-defined TLVs not sent — fixes #231
Unknown/custom TLVs addressed by their numeric tag id (e.g. `pdu[0x3C02] = Buffer.from(...)`)
were parsed on decode but silently dropped on encode. They now round-trip: the PDU
constructor keeps numeric-tag keys and `toBuffer()` writes them.

### Tests
Adds `test/fixes.js`. All existing tests still pass (the only failure in CI-less
local runs is the pre-existing network-dependent invalid-host DNS test).

---
These fixes are also available, alongside a full TypeScript rewrite (dual ESM+CJS,
types, Bun support) and more features, in the maintained fork
https://github.com/fdciabdul/node-smpp-next — but this PR intentionally keeps the
changes minimal and JS-only for easy review/merge here.
@